### PR TITLE
Disable highlighter HTML output tests (#11)

### DIFF
--- a/test/nuzzle/content_test.clj
+++ b/test/nuzzle/content_test.clj
@@ -39,31 +39,28 @@
     (is (= (list "pygmentize" "-f" "html" "-l" "clojure" "-O" "noclasses,style=algol_nu,linenos=inline" "/tmp/foo.clj")
            (con/generate-highlight-command "/tmp/foo.clj" "clojure" {:markdown-opts {:syntax-highlighting {:provider :pygments :style "algol_nu" :line-numbers? true}}})))))
 
-(deftest highlight-code
-  (let [code "(def foo (let [x (+ 5 7)] (println x)))"]
-    ;; Chroma 2.2.0
-    (testing "chroma HTML output"
-      (is (= "<span class=\"p\">(</span><span class=\"k\">def </span><span class=\"nv\">foo</span> <span class=\"p\">(</span><span class=\"k\">let </span><span class=\"p\">[</span><span class=\"nv\">x</span> <span class=\"p\">(</span><span class=\"nb\">+ </span><span class=\"mi\">5</span> <span class=\"mi\">7</span><span class=\"p\">)]</span> <span class=\"p\">(</span><span class=\"nb\">println </span><span class=\"nv\">x</span><span class=\"p\">)))</span>"
-             (con/highlight-code code "clojure" {:markdown-opts {:syntax-highlighting {:provider :chroma}}})))
-      (is (= "(<span style=\"color:#fb660a;font-weight:bold\">def </span><span style=\"color:#fb660a\">foo</span> (<span style=\"color:#fb660a;font-weight:bold\">let </span>[<span style=\"color:#fb660a\">x</span> (+ <span style=\"color:#0086f7;font-weight:bold\">5</span> <span style=\"color:#0086f7;font-weight:bold\">7</span>)] (println <span style=\"color:#fb660a\">x</span>)))"
-             (con/highlight-code code "clojure" {:markdown-opts {:syntax-highlighting {:provider :chroma :style "fruity"}}})))
-      (is (= "<span class=\"p\">(</span><span class=\"k\">def </span><span class=\"nv\">foo</span> <span class=\"p\">(</span><span class=\"k\">let </span><span class=\"p\">[</span><span class=\"nv\">x</span> <span class=\"p\">(</span><span class=\"nb\">+ </span><span class=\"mi\">5</span> <span class=\"mi\">7</span><span class=\"p\">)]</span> <span class=\"p\">(</span><span class=\"nb\">println </span><span class=\"nv\">x</span><span class=\"p\">)))</span>"
-             (con/highlight-code code "clojure" {:markdown-opts {:syntax-highlighting {:provider :chroma :line-numbers? true}}})))
-      (is (= "(<span style=\"color:#fb660a;font-weight:bold\">def </span><span style=\"color:#fb660a\">foo</span> (<span style=\"color:#fb660a;font-weight:bold\">let </span>[<span style=\"color:#fb660a\">x</span> (+ <span style=\"color:#0086f7;font-weight:bold\">5</span> <span style=\"color:#0086f7;font-weight:bold\">7</span>)] (println <span style=\"color:#fb660a\">x</span>)))"
-             (con/highlight-code code "clojure" {:markdown-opts {:syntax-highlighting {:provider :chroma :style "fruity" :line-numbers? true}}}))))
-    ;; Pygmentize 2.12.0
-    (testing "pygments HTML output"
-      (is (= "<span class=\"p\">(</span><span class=\"k\">def </span><span class=\"nv\">foo</span><span class=\"w\"> </span><span class=\"p\">(</span><span class=\"k\">let </span><span class=\"p\">[</span><span class=\"nv\">x</span><span class=\"w\"> </span><span class=\"p\">(</span><span class=\"nb\">+ </span><span class=\"mi\">5</span><span class=\"w\"> </span><span class=\"mi\">7</span><span class=\"p\">)]</span><span class=\"w\"> </span><span class=\"p\">(</span><span class=\"nb\">println </span><span class=\"nv\">x</span><span class=\"p\">)))</span><span class=\"w\"></span>\n"
-             (con/highlight-code code "clojure" {:markdown-opts {:syntax-highlighting {:provider :pygments}}})))
-
-      (is (= "<span style=\"color: #ffffff\">(</span><span style=\"color: #fb660a; font-weight: bold\">def </span><span style=\"color: #fb660a\">foo</span><span style=\"color: #888888\"> </span><span style=\"color: #ffffff\">(</span><span style=\"color: #fb660a; font-weight: bold\">let </span><span style=\"color: #ffffff\">[</span><span style=\"color: #fb660a\">x</span><span style=\"color: #888888\"> </span><span style=\"color: #ffffff\">(+ </span><span style=\"color: #0086f7; font-weight: bold\">5</span><span style=\"color: #888888\"> </span><span style=\"color: #0086f7; font-weight: bold\">7</span><span style=\"color: #ffffff\">)]</span><span style=\"color: #888888\"> </span><span style=\"color: #ffffff\">(println </span><span style=\"color: #fb660a\">x</span><span style=\"color: #ffffff\">)))</span><span style=\"color: #888888\"></span>\n"
-             (con/highlight-code code "clojure" {:markdown-opts {:syntax-highlighting {:provider :pygments :style "fruity"}}})))
-
-      (is (= (con/highlight-code "(def foo (let [x (+ 5 7)] (println x)))" "clojure" {:markdown-opts {:syntax-highlighting {:provider :pygments :line-numbers? true}}})
-             (con/highlight-code code "clojure" {:markdown-opts {:syntax-highlighting {:provider :pygments :line-numbers? true}}})
-             ))
-
-      )))
+;; (deftest highlight-code
+;;   (let [code "(def foo (let [x (+ 5 7)] (println x)))"]
+;;     ;; Chroma 2.2.0
+;;     (testing "chroma HTML output"
+;;       (is (= "<span class=\"p\">(</span><span class=\"k\">def </span><span class=\"nv\">foo</span> <span class=\"p\">(</span><span class=\"k\">let </span><span class=\"p\">[</span><span class=\"nv\">x</span> <span class=\"p\">(</span><span class=\"nb\">+ </span><span class=\"mi\">5</span> <span class=\"mi\">7</span><span class=\"p\">)]</span> <span class=\"p\">(</span><span class=\"nb\">println </span><span class=\"nv\">x</span><span class=\"p\">)))</span>"
+;;              (con/highlight-code code "clojure" {:markdown-opts {:syntax-highlighting {:provider :chroma}}})))
+;;       (is (= "(<span style=\"color:#fb660a;font-weight:bold\">def </span><span style=\"color:#fb660a\">foo</span> (<span style=\"color:#fb660a;font-weight:bold\">let </span>[<span style=\"color:#fb660a\">x</span> (+ <span style=\"color:#0086f7;font-weight:bold\">5</span> <span style=\"color:#0086f7;font-weight:bold\">7</span>)] (println <span style=\"color:#fb660a\">x</span>)))"
+;;              (con/highlight-code code "clojure" {:markdown-opts {:syntax-highlighting {:provider :chroma :style "fruity"}}})))
+;;       (is (= "<span class=\"p\">(</span><span class=\"k\">def </span><span class=\"nv\">foo</span> <span class=\"p\">(</span><span class=\"k\">let </span><span class=\"p\">[</span><span class=\"nv\">x</span> <span class=\"p\">(</span><span class=\"nb\">+ </span><span class=\"mi\">5</span> <span class=\"mi\">7</span><span class=\"p\">)]</span> <span class=\"p\">(</span><span class=\"nb\">println </span><span class=\"nv\">x</span><span class=\"p\">)))</span>"
+;;              (con/highlight-code code "clojure" {:markdown-opts {:syntax-highlighting {:provider :chroma :line-numbers? true}}})))
+;;       (is (= "(<span style=\"color:#fb660a;font-weight:bold\">def </span><span style=\"color:#fb660a\">foo</span> (<span style=\"color:#fb660a;font-weight:bold\">let </span>[<span style=\"color:#fb660a\">x</span> (+ <span style=\"color:#0086f7;font-weight:bold\">5</span> <span style=\"color:#0086f7;font-weight:bold\">7</span>)] (println <span style=\"color:#fb660a\">x</span>)))"
+;;              (con/highlight-code code "clojure" {:markdown-opts {:syntax-highlighting {:provider :chroma :style "fruity" :line-numbers? true}}}))))
+;;     ;; Pygmentize 2.12.0
+;;     (testing "pygments HTML output"
+;;       (is (= "<span class=\"p\">(</span><span class=\"k\">def </span><span class=\"nv\">foo</span><span class=\"w\"> </span><span class=\"p\">(</span><span class=\"k\">let </span><span class=\"p\">[</span><span class=\"nv\">x</span><span class=\"w\"> </span><span class=\"p\">(</span><span class=\"nb\">+ </span><span class=\"mi\">5</span><span class=\"w\"> </span><span class=\"mi\">7</span><span class=\"p\">)]</span><span class=\"w\"> </span><span class=\"p\">(</span><span class=\"nb\">println </span><span class=\"nv\">x</span><span class=\"p\">)))</span><span class=\"w\"></span>\n"
+;;              (con/highlight-code code "clojure" {:markdown-opts {:syntax-highlighting {:provider :pygments}}})))
+;;
+;;       (is (= "<span style=\"color: #ffffff\">(</span><span style=\"color: #fb660a; font-weight: bold\">def </span><span style=\"color: #fb660a\">foo</span><span style=\"color: #888888\"> </span><span style=\"color: #ffffff\">(</span><span style=\"color: #fb660a; font-weight: bold\">let </span><span style=\"color: #ffffff\">[</span><span style=\"color: #fb660a\">x</span><span style=\"color: #888888\"> </span><span style=\"color: #ffffff\">(+ </span><span style=\"color: #0086f7; font-weight: bold\">5</span><span style=\"color: #888888\"> </span><span style=\"color: #0086f7; font-weight: bold\">7</span><span style=\"color: #ffffff\">)]</span><span style=\"color: #888888\"> </span><span style=\"color: #ffffff\">(println </span><span style=\"color: #fb660a\">x</span><span style=\"color: #ffffff\">)))</span><span style=\"color: #888888\"></span>\n"
+;;              (con/highlight-code code "clojure" {:markdown-opts {:syntax-highlighting {:provider :pygments :style "fruity"}}})))
+;;
+;;       (is (= (con/highlight-code "(def foo (let [x (+ 5 7)] (println x)))" "clojure" {:markdown-opts {:syntax-highlighting {:provider :pygments :line-numbers? true}}})
+;;              (con/highlight-code code "clojure" {:markdown-opts {:syntax-highlighting {:provider :pygments :line-numbers? true}}}))))))
 
 (deftest create-render-content-fn
   (let [{:keys [content]} (get-in (config) [:site-data [:about]])


### PR DESCRIPTION
These tests make chroma and pygmentize dependencies for the unit tests
which adds complexity to testing and CI. They are disabled for now but
might re-enabled later on.

Fixes #11 