### PR TITLE
Rename export to publish in config and api namespace (#2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Want to read some code already? Check out [this repo](https://github.com/stelcod
 
 ## Nuzzle's API
 Nuzzle's whole interface is just three functions in the `nuzzle.api` namespace:
-- `export`: Exports the static site to disk.
+- `publish`: Exports the static site to disk.
 - `serve`: Starts a web server (http-kit) for a live preview of the website, building each webpage from scratch upon each request.
 - `realize`: Helper function for visualizing your site data after Nuzzle's additions.
 
@@ -55,8 +55,8 @@ Nuzzle expects to find an EDN map in the file `nuzzle.edn` in your current worki
 - `:nuzzle/base-url` - URI where site will be hosted. Must start with "http://" or "https://". Required.
 - `:site-data` - A set of maps describing the structure and content of your website. Required.
 - `:render-webpage` - A fully qualified symbol pointing to your webpage rendering function. Required.
-- `:export-dir` - A path to a directory to export the site into. Defaults to `"out"`.
-- `:overlay-dir` - A path to a directory that will be overlayed on top of `:export-dir` as the final stage of exporting. Defaults to `nil` (no overlay).
+- `:nuzzle/publish-dir` - A path to a directory to publish the site into. Defaults to `"out"`.
+- `:overlay-dir` - A path to a directory that will be overlayed on top of the `:nuzzle/publish-dir` directory as the final stage of publishing. Defaults to `nil` (no overlay).
 - `:markdown-opts` - A map of markdown processing options (syntax highlighting, shortcodes)
 - `:rss-channel` - A map with an RSS channel specification. Defaults to nil (no RSS feed).
 - `:remove-drafts?` - A boolean that indicates whether webpages marked as a draft should be removed. Defaults to nil (no draft removal).
@@ -86,7 +86,7 @@ If you're from Pallet town, your `nuzzle.edn` config might look like this:
 ## Site Data
 The `:site-data` value defines the attributes of all the static site's webpages as well as any supplemental information. Site data must be a set of maps, and those maps have just one required key: `:id`.
 
-If the `:id` is a **vector of keywords**, the map represents a typical **webpage**. The `:id` `[:blog-posts :catching-pikachu]` translates to the URI `"/blog-posts/catching-pikachu"` and will be rendered to disk as `<export-dir>/blog-posts/catching-pikachu/index.html`. Nuzzle calls these *webpage maps*.
+If the `:id` is a **vector of keywords**, the map represents a typical **webpage**. The `:id` `[:blog-posts :catching-pikachu]` translates to the URI `"/blog-posts/catching-pikachu"` and will be rendered to disk as `<publish-dir>/blog-posts/catching-pikachu/index.html`. Nuzzle calls these *webpage maps*.
 
 If the `:id` is a singular **keyword**, the map just contains extra information about the site. It has no effect on the website structure. Nuzzle calls these *peripheral maps*. The last map in the example above with the `:id` of `:crypto` is a peripheral map.
 
@@ -158,7 +158,7 @@ Nuzzle's site data pipeline can be visualized like so:
    │ Site data │ ────┬───► │ Realized  │ ─────┬─────►  │  Hiccup that │
    │   from    │     │     │ site data │      │        │ is converted │
    │ nuzzle.edn│     │     │           │      │        │ to html and  │
-   │           │           │           │               │   exported   │
+   │           │           │           │               │  published   │
    └───────────┘  Nuzzle   └───────────┘render-webpage │              │
                  additions                 function    └──────────────┘
 ```
@@ -179,7 +179,7 @@ Nuzzle adds these keys to every peripheral map:
 ### Adding Webpage Maps (Index Webpages)
 Often people want to create index webpages in static sites which serve as a webpage that links to other webpages which share a common trait. For example, if you have webpages like `"/blog-posts/foo"` and `"/blog-posts/bar"`, you may want a webpage at `"/blog-posts"` that links to `"/blog-posts/foo"` and `"/blog-posts/bar"`. Nuzzle calls these *subdirectory index webpages*. Another common pattern is associating tags with webpages. You may want to add index pages like `"/tags/clojure"` so you can link to all your webpages about Clojure. Nuzzle calls these *tag index webpages*. Nuzzle adds both subdirectory and tag index webpages automatically for all subdirectories and tags present in your site data.
 
-> You may not want to export all the index webpages that Nuzzle adds to your site data. That's ok! You can control which webpages get exported inside your webpage rendering function.
+> You may not want to publish all the index webpages that Nuzzle adds to your site data. That's ok! You can control which webpages get published inside your webpage rendering function.
 
 What makes these index webpage maps special? They have an `:index` key with a value that is a set of webpage map `id`s for any webpages directly below them. For example, if you had webpage maps with `id`s of `[:blog-posts :foo]` and `[:blog-posts :bar]`, Nuzzle would add a webpage map with an `:id` of `[:blog-posts]` and an `:index` of `#{[:blog-posts :foo] [:blog-posts :bar]}`.
 
@@ -216,7 +216,7 @@ Here's an example of a webpage rendering function called `simple-render-webpage`
 
 The `render-webpage` function uses the `:id` value to determine what Hiccup to return. This is how a single function can produce Hiccup for every webpage.
 
-Just because a webpage exists in your realized site data doesn't mean you have to include it in your static site. If you don't want a webpage to be exported, just return `nil`.
+Just because a webpage exists in your realized site data doesn't mean you have to include it in your static site. If you don't want a webpage to be published, just return `nil`.
 
 ### Accessing Your Site Data with `get-site-data`
 With many static site generators, accessing global data inside markup templates can be painful to say the least. Nuzzle strives to solve this difficult problem elegantly with a function called `get-site-data`. While realizing your site data, Nuzzle attaches a copy of this function to each webpage map under the key `:get-site-data`.

--- a/src/nuzzle/api.clj
+++ b/src/nuzzle/api.clj
@@ -1,6 +1,6 @@
 (ns nuzzle.api
   (:require [nuzzle.config :as conf]
-            [nuzzle.export :as export]
+            [nuzzle.publish :as publish]
             [nuzzle.log :as log]
             [nuzzle.ring :as ring]
             [nuzzle.util :as util]))
@@ -13,14 +13,15 @@
     (log/info "🔍🐈 Printing realized site data for inspection")
     (util/convert-site-data-to-set config)))
 
-(defn export
-  "Exports the website to :export-dir. The :overlay-dir is overlayed on top of
-  the :export-dir after the web pages have been exported."
+(defn publish
+  "Publishes the website to :nuzzle/publish-dir. The overlay directory is
+  overlayed on top of the publish directory after the web pages have been
+  published."
   [& {:as config-overrides}]
   {:pre [(or (nil? config-overrides) (map? config-overrides))]}
   (-> config-overrides
       (conf/load-default-config)
-      (export/export-site)))
+      (publish/publish-site)))
 
 (defn serve
   "Starts a server using http-kit for development."

--- a/src/nuzzle/config.clj
+++ b/src/nuzzle/config.clj
@@ -32,7 +32,7 @@
   [config-path config-overrides]
   {:pre [(string? config-path) (or (nil? config-overrides) (map? config-overrides))]
    :post [(map? %)]}
-  (let [config-defaults {:export-dir "out" :server-port 6899}
+  (let [config-defaults {:nuzzle/publish-dir "out" :server-port 6899}
         edn-config
         (try
           (edn/read-string (slurp config-path))

--- a/src/nuzzle/log.clj
+++ b/src/nuzzle/log.clj
@@ -34,11 +34,11 @@
 (defn log-sitemap [sitemap-file]
   (info "📖🐈 Creating sitemap file:" (fs/canonicalize sitemap-file)))
 
-(defn log-export-start [export-dir]
-  (info "🔨🐈 Exporting static site to:" (fs/canonicalize export-dir)))
+(defn log-publish-start [publish-dir]
+  (info "🔨🐈 Publishing static site to:" (fs/canonicalize publish-dir)))
 
-(defn log-export-end []
-  (info "✅🐈 Export successful"))
+(defn log-publish-end []
+  (info "✅🐈 Publishing successful"))
 
 (defn log-start-server [server-port]
   (info "✨🐈 Starting development server on port" server-port))

--- a/src/nuzzle/publish.clj
+++ b/src/nuzzle/publish.clj
@@ -1,4 +1,4 @@
-(ns nuzzle.export
+(ns nuzzle.publish
   (:require
    [babashka.fs :as fs]
    [nuzzle.generator :as gen]
@@ -8,33 +8,33 @@
    [nuzzle.util :as util]
    [stasis.core :as stasis]))
 
-(defn export-rss
-  [{:keys [export-dir] :as config}]
-  (let [rss-file (fs/file export-dir "feed.xml")
+(defn publish-rss
+  [{:keys [publish-dir] :as config}]
+  (let [rss-file (fs/file publish-dir "feed.xml")
         _ (log/log-rss rss-file)
         rss-feed (rss/create-rss-feed config)]
     (spit rss-file rss-feed)))
 
-(defn export-sitemap
-  [{:keys [export-dir] :as config} rendered-site-index]
-  (let [sitemap-file (fs/file export-dir "sitemap.xml")
+(defn publish-sitemap
+  [{:keys [publish-dir] :as config} rendered-site-index]
+  (let [sitemap-file (fs/file publish-dir "sitemap.xml")
         _ (log/log-sitemap sitemap-file)
         sitemap-str (sitemap/create-sitemap config rendered-site-index)]
     (spit sitemap-file sitemap-str)))
 
-(defn export-site
-  [{:keys [sitemap? overlay-dir export-dir rss-channel] :as config}]
+(defn publish-site
+  [{:keys [sitemap? overlay-dir publish-dir rss-channel] :as config}]
   (let [rendered-site-index (gen/generate-rendered-site-index config)]
-    (log/log-export-start export-dir)
-    (fs/create-dirs export-dir)
-    (stasis/empty-directory! export-dir)
-    (stasis/export-pages rendered-site-index export-dir)
+    (log/log-publish-start publish-dir)
+    (fs/create-dirs publish-dir)
+    (stasis/empty-directory! publish-dir)
+    (stasis/export-pages rendered-site-index publish-dir)
     (when overlay-dir
       (log/log-overlay-dir overlay-dir)
       (util/ensure-overlay-dir overlay-dir)
-      (fs/copy-tree overlay-dir export-dir))
+      (fs/copy-tree overlay-dir publish-dir))
     (when rss-channel
-      (export-rss config))
+      (publish-rss config))
     (when sitemap?
-      (export-sitemap config rendered-site-index))
-    (log/log-export-end)))
+      (publish-sitemap config rendered-site-index))
+    (log/log-publish-end)))

--- a/src/nuzzle/schemas.clj
+++ b/src/nuzzle/schemas.clj
@@ -51,7 +51,7 @@
    [:nuzzle/base-url base-url]
    [:markdown-opts {:optional true} markdown-opts]
    [:overlay-dir {:optional true} string?]
-   [:export-dir {:optional true} string?]
+   [:nuzzle/publish-dir {:optional true} string?]
    [:rss-channel {:optional true} [:map {:closed true}
                                    [:title string?]
                                    [:link string?]

--- a/test-resources/edn/config-1.edn
+++ b/test-resources/edn/config-1.edn
@@ -6,7 +6,7 @@
                :link "https://foobar.com"}
  :sitemap? true
  :overlay-dir "public"
- :export-dir "/tmp/nuzzle-test-out"
+ :nuzzle/publish-dir "/tmp/nuzzle-test-out"
  :site-data
  #{{:id []}
 

--- a/test/nuzzle/config_test.clj
+++ b/test/nuzzle/config_test.clj
@@ -20,7 +20,7 @@
 
 (deftest read-specified-config
   (is (= (conf/read-specified-config config-path {})
-         {:export-dir "/tmp/nuzzle-test-out",
+         {:nuzzle/publish-dir "/tmp/nuzzle-test-out",
           :server-port 6899,
           :nuzzle/base-url "https://foobar.com"
           :sitemap? true

--- a/test/nuzzle/integration_test.clj
+++ b/test/nuzzle/integration_test.clj
@@ -77,7 +77,7 @@
 (deftest realize-site-data
   (is (= (-> (read-ash-config) transform-ash-config create-ash-config-file
              (conf/load-specified-config {}) normalize-loaded-config)
-         {:export-dir "out",
+         {:nuzzle/publish-dir "out",
           :server-port 6899,
           :nuzzle/base-url "https://ashketchum.com",
           :overlay-dir "test-resources/overlay",


### PR DESCRIPTION
Instead of using the phrase "export", use "publish" instead.

Fixes #2 