### PR TITLE
Only run push-triggered GitHub action unit tests on main branch

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,7 +1,9 @@
 name: unit-tests
 on:
-  - push
-  - pull_request
+  push:
+      branches:
+        - main
+  pull_request:
 jobs:
   run-clojure-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
When raising PRs with branches inside origin, the unit tests have to run
twice (once for the push, once for the PR) so this change makes `main`
the only branch that runs unit tests on push.

Fixes #17