### PR TITLE
Rename :remove-drafts? to :nuzzle/build-drafts? (#4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Nuzzle expects to find an EDN map in the file `nuzzle.edn` in your current worki
 - `:overlay-dir` - A path to a directory that will be overlayed on top of the `:nuzzle/publish-dir` directory as the final stage of publishing. Defaults to `nil` (no overlay).
 - `:markdown-opts` - A map of markdown processing options (syntax highlighting, shortcodes)
 - `:rss-channel` - A map with an RSS channel specification. Defaults to nil (no RSS feed).
-- `:remove-drafts?` - A boolean that indicates whether pages marked as a draft should be removed. Defaults to nil (no draft removal).
+- `:nuzzle/build-drafts?` - A boolean that indicates whether pages marked as a draft should be removed. Defaults to nil (no draft removal).
 - `:server-port` - A port number for the development server to listen on. Defaults to 6899.
 
 If you're from Pallet town, your `nuzzle.edn` config might look like this:

--- a/src/nuzzle/generator.clj
+++ b/src/nuzzle/generator.clj
@@ -84,11 +84,12 @@
 
 (defn realize-site-data
   "Creates fully realized site-data datastructure with or without drafts."
-  [{:keys [remove-drafts? site-data] :as config}]
+  [{:keys [nuzzle/build-drafts? site-data] :as config}]
   {:pre [(set? site-data)] :post [#(map? %)]}
   ;; Allow users to define their own overrides via deep-merge
   (-> config
-      (update :site-data #(if-not remove-drafts? %
+      (update :site-data #(if build-drafts?
+                            (do (log/log-build-drafts) %)
                             (do (log/log-remove-drafts)
                               (remove :draft? %))))
       (update :site-data #(util/convert-site-data-to-map %))

--- a/src/nuzzle/log.clj
+++ b/src/nuzzle/log.clj
@@ -28,6 +28,9 @@
 (defn log-remove-drafts []
   (info "❌🐈 Removing drafts"))
 
+(defn log-build-drafts []
+  (info "🔨🐈 Building drafts"))
+
 (defn log-rss [rss-file]
   (info "📰🐈 Creating RSS file:" (fs/canonicalize rss-file)))
 
@@ -35,7 +38,7 @@
   (info "📖🐈 Creating sitemap file:" (fs/canonicalize sitemap-file)))
 
 (defn log-publish-start [publish-dir]
-  (info "🔨🐈 Publishing static site to:" (fs/canonicalize publish-dir)))
+  (info "💫🐈 Publishing static site to:" (fs/canonicalize publish-dir)))
 
 (defn log-publish-end []
   (info "✅🐈 Publishing successful"))

--- a/src/nuzzle/schemas.clj
+++ b/src/nuzzle/schemas.clj
@@ -57,5 +57,5 @@
                                    [:link string?]
                                    [:description string?]]]
    [:sitemap? {:optional true} :boolean]
-   [:remove-drafts? {:optional true} boolean?]
+   [:nuzzle/build-drafts? {:optional true} boolean?]
    [:server-port {:optional true} [:and int? [:> 1023] [:< 65536]]]])

--- a/test-resources/edn/config-1.edn
+++ b/test-resources/edn/config-1.edn
@@ -1,4 +1,4 @@
-{:remove-drafts? false
+{:nuzzle/build-drafts? true
  :nuzzle/base-url "https://foobar.com"
  :nuzzle/render-page nuzzle.config-test/render-page
  :rss-channel {:title "Foo's blog"

--- a/test/nuzzle/config_test.clj
+++ b/test/nuzzle/config_test.clj
@@ -24,7 +24,7 @@
           :server-port 6899,
           :nuzzle/base-url "https://foobar.com"
           :sitemap? true
-          :remove-drafts? false,
+          :nuzzle/build-drafts? true,
           :nuzzle/render-page render-page,
           :rss-channel
           {:title "Foo's blog",

--- a/test/nuzzle/generator_test.clj
+++ b/test/nuzzle/generator_test.clj
@@ -93,14 +93,4 @@
   (is (= "/blog-posts/my-hobbies/" (util/id->uri [:blog-posts :my-hobbies])))
   (is (= "/about/" (util/id->uri [:about]))))
 
-#_
-(deftest realize-site-data
-  (is (= (gen/realize-site-data (:site-data nuzzle-config) (:remove-drafts? nuzzle-config)))))
-
-#_
-(deftest export
-  (let [y {[:about] {:title "About"}}
-        x {:config y :include-drafts? true :render-webpage (constantly "<h1>Test</h1>") :export-dir "/tmp/out"}]
-    (generator/export x)))
-
 (comment (run-tests))


### PR DESCRIPTION
The default stays as nil so now Nuzzle will not build drafts by default. Previously Nuzzle included drafts by default.

Fixes #4