### PR TITLE
Pull out :shortcode-fns to config top-level, rename to :nuzzle/custom-elements (#37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,10 @@ Nuzzle expects to find an EDN map in the file `nuzzle.edn` in your current worki
 - `:nuzzle/render-page` - A fully qualified symbol pointing to your page rendering function. Required.
 - `:nuzzle/publish-dir` - A path to a directory to publish the site into. Defaults to `"out"`.
 - `:nuzzle/overlay-dir` - A path to a directory that will be overlayed on top of the `:nuzzle/publish-dir` directory as the final stage of publishing. Defaults to `nil` (no overlay).
-- `:markdown-opts` - A map of markdown processing options (syntax highlighting, shortcodes)
+- `:markdown-opts` - A map of markdown processing options (syntax highlighting)
 - `:nuzzle/rss-channel` - A map with an RSS channel specification. Defaults to nil (no RSS feed).
 - `:nuzzle/build-drafts?` - A boolean that indicates whether pages marked as a draft should be removed. Defaults to nil (no draft removal).
+- `:nuzzle/custom-elements` - A map of keywords -> symbols which define functions to transform the Hiccup representation of custom HTML elements.
 - `:nuzzle/server-port` - A port number for the development server to listen on. Defaults to 6899.
 
 If you're from Pallet town, your `nuzzle.edn` config might look like this:

--- a/src/nuzzle/content.clj
+++ b/src/nuzzle/content.clj
@@ -10,47 +10,47 @@
    [nuzzle.util :as util]
    [vimhelp.core :as vimhelp]))
 
-(defn quickfigure-shortcode
+(defn quickfigure-element
   [[_tag {:keys [src title] :as _attr}]]
   [:figure [:img {:src src}]
    [:figcaption [:h4 title]]])
 
-(defn gist-shortcode
+(defn gist-element
   [[_tag {:keys [user id] :as _attr}]]
   [:script {:type "application/javascript"
             :src (str "https://gist.github.com/" user "/" id ".js")}])
 
-(defn youtube-shortcode
+(defn youtube-element
   [[_tag {:keys [title id] :as _attr}]]
   [:div {:style "position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;"}
    [:iframe {:src (str "https://www.youtube.com/embed/" id)
              :style "position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;"
              :title title :allowfullscreen true}]])
 
-(defn vimhelp-shortcode
+(defn vimhelp-element
   [[_tag {:keys [src badrefs] :or {badrefs ""} :as _attr}]]
   (vimhelp/help-file->hiccup src (set (str/split badrefs #","))))
 
-(defn render-shortcode
+(defn render-custom-element
   [[tag & _ :as hiccup]]
   (case tag
-    :quickfigure (quickfigure-shortcode hiccup)
-    :gist (gist-shortcode hiccup)
-    :vimhelp (vimhelp-shortcode hiccup)
-    :youtube (youtube-shortcode hiccup)
+    :quickfigure (quickfigure-element hiccup)
+    :gist (gist-element hiccup)
+    :vimhelp (vimhelp-element hiccup)
+    :youtube (youtube-element hiccup)
     hiccup))
 
-(defn walk-hiccup-for-shortcodes
+(defn walk-hiccup-for-custom-elements
   [hiccup]
   {:pre [(sequential? hiccup)]}
   (if (list? hiccup)
-    (map walk-hiccup-for-shortcodes hiccup)
+    (map walk-hiccup-for-custom-elements hiccup)
     (w/prewalk
      (fn [item]
        (if (cu/hiccup? item)
          (if (-> item second map?)
-           (render-shortcode item)
-           (render-shortcode (apply vector (first item) {} (rest item))))
+           (render-custom-element item)
+           (render-custom-element (apply vector (first item) {} (rest item))))
          item))
      hiccup)))
 
@@ -109,7 +109,7 @@
         [_ _ & hiccup] (-> file
                            slurp
                            (cm/parse-body {:lower-fns lower-fns}))]
-    (walk-hiccup-for-shortcodes hiccup)))
+    (walk-hiccup-for-custom-elements hiccup)))
 
 (defn process-html-file
   [content-file _config]

--- a/src/nuzzle/schemas.clj
+++ b/src/nuzzle/schemas.clj
@@ -32,10 +32,7 @@
      ;; TODO: Add option to specify custom highlighting command
      [:provider [:enum :chroma :pygments]]
      [:style {:optional true} [:or :string :nil]]
-     [:line-numbers? {:optional true} :boolean]]]
-   [:shortcode-fns
-    {:optional true}
-    [:map-of :keyword :symbol]]])
+     [:line-numbers? {:optional true} :boolean]]]])
 
 (def base-url
   [:and
@@ -50,6 +47,7 @@
    [:nuzzle/render-page fn?]
    [:nuzzle/base-url base-url]
    [:markdown-opts {:optional true} markdown-opts]
+   [:nuzzle/custom-elements {:optional true} [:map-of :keyword :symbol]]
    [:nuzzle/overlay-dir {:optional true} string?]
    [:nuzzle/publish-dir {:optional true} string?]
    [:nuzzle/rss-channel {:optional true} [:map {:closed true}

--- a/test/nuzzle/content_test.clj
+++ b/test/nuzzle/content_test.clj
@@ -9,15 +9,15 @@
 
 (defn config [] (conf/load-specified-config config-path {}))
 
-(deftest vimhelp-shortcode
-    (is (= (hiccup/html-document (con/vimhelp-shortcode [:vimhelp {:src "test-resources/txt/conjure.txt"}]))
+(deftest vimhelp-element
+    (is (= (hiccup/html-document (con/vimhelp-element [:vimhelp {:src "test-resources/txt/conjure.txt"}]))
            (slurp "test-resources/html/conjure-no-badrefs-filter.html")))
-    (is (= (hiccup/html-document (con/vimhelp-shortcode [:vimhelp {:src "test-resources/txt/conjure.txt" :badrefs "omnifunc,maplocalleader,splitbelow,splitright,Ctrl-O,mark,searchpairpos(),User,autocmds,complete-functions,ExitPre"}]))
+    (is (= (hiccup/html-document (con/vimhelp-element [:vimhelp {:src "test-resources/txt/conjure.txt" :badrefs "omnifunc,maplocalleader,splitbelow,splitright,Ctrl-O,mark,searchpairpos(),User,autocmds,complete-functions,ExitPre"}]))
            (slurp "test-resources/html/conjure-with-badrefs-filter.html"))))
 
-(comment (con/vimhelp-shortcode [:vimhelp "hi"]))
-(comment (spit "test-resources/html/conjure-no-badrefs-filter.html" (hiccup/html-document (con/vimhelp-shortcode {:src "test-resources/txt/conjure.txt"}))))
-(comment (spit "test-resources/html/conjure-with-badrefs-filter.html" (hiccup/html-document (con/vimhelp-shortcode {:src "test-resources/txt/conjure.txt" :badrefs "omnifunc,maplocalleader,splitbelow,splitright,Ctrl-O,mark,searchpairpos(),User,autocmds,complete-functions,ExitPre"}))))
+(comment (con/vimhelp-element [:vimhelp "hi"]))
+(comment (spit "test-resources/html/conjure-no-badrefs-filter.html" (hiccup/html-document (con/vimhelp-element {:src "test-resources/txt/conjure.txt"}))))
+(comment (spit "test-resources/html/conjure-with-badrefs-filter.html" (hiccup/html-document (con/vimhelp-element {:src "test-resources/txt/conjure.txt" :badrefs "omnifunc,maplocalleader,splitbelow,splitright,Ctrl-O,mark,searchpairpos(),User,autocmds,complete-functions,ExitPre"}))))
 
 (deftest generate-highlight-command
   (testing "generating chroma command"
@@ -69,8 +69,8 @@
     (is (= (list [:h1 {:id "about"} "About"] [:p {} "This is a site for testing the Clojure static site generator called Nuzzle."])
            (render-content)))))
 
-(deftest walk-hiccup-for-shortcodes
-  (let [hiccup-with-shortcode [:div {:class "hi"} [:youtube {:title "some title" :id "12345"}]]
+(deftest walk-hiccup-for-custom-elements
+  (let [hiccup-with-custom-element [:div {:class "hi"} [:youtube {:title "some title" :id "12345"}]]
         expected-result
         [:div {:class "hi"}
          [:div
@@ -82,11 +82,11 @@
             "position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;",
             :title "some title",
             :allowfullscreen true}]]]]
-    (is (= (con/walk-hiccup-for-shortcodes (list [:div] hiccup-with-shortcode))
+    (is (= (con/walk-hiccup-for-custom-elements (list [:div] hiccup-with-custom-element))
            (list
             [:div]
             expected-result)))
-    (is (= (con/walk-hiccup-for-shortcodes hiccup-with-shortcode)
+    (is (= (con/walk-hiccup-for-custom-elements hiccup-with-custom-element)
            expected-result))))
 
 (comment ((con/create-render-content-fn [:inline-html] "test-resources/markdown/inline-html.md" nil))

--- a/test/nuzzle/schemas_test.clj
+++ b/test/nuzzle/schemas_test.clj
@@ -9,10 +9,7 @@
   (is (m/validate schemas/markdown-opts
                   {:syntax-highlighting
                    {:provider :chroma
-                    :style "emacs"}
-                   :shortcode-fns
-                   {:foobar 'shortcodes/foobar
-                    :foobaz 'shortcodes/foobaz}})))
+                    :style "emacs"}})))
 
 (deftest local-date
   (is (m/validate schemas/local-date


### PR DESCRIPTION
The shortcode-fns setting is not well documented right now, but it
basically provides a way to define custom HTML tags with functions that
transform that element when it represented as Hiccup. This config
setting was previously located inside :markdown-opts, but now it's at
the top-level because it will eventually transcend Markdown usage to be
used with raw HTML as well.

I think custom-elements is a better name because it actually reflects
HTML custom elements in the browser quite well, it's just that these
custom elements are being rendered statically server side.

Adding nuzzle namespace to keyword to go along with #6.

Fixes #37