### PR TITLE
Rename special config key :uri to :nuzzle/url (#7)

### DIFF
--- a/src/nuzzle/generator.clj
+++ b/src/nuzzle/generator.clj
@@ -51,14 +51,14 @@
         {})))
 
 (defn realize-pages
-  "Adds :uri, :render-content keys to each page in the site-data."
+  "Adds :nuzzle/url, :render-content keys to each page in the site-data."
   [{:keys [site-data] :as config}]
   {:pre [(map? site-data)]}
   (->> site-data
        (reduce-kv
-        (fn [m id {:keys [content uri] :as v}]
+        (fn [m id {:keys [content url] :as v}]
           (if (vector? id)
-            (assoc m id (merge v {:uri (or uri (util/id->uri id))
+            (assoc m id (merge v {:nuzzle/url (or url (util/id->url id))
                                   :render-content
                                   (con/create-render-content-fn id content config)}))
             (assoc m id (merge v {:render-content
@@ -112,7 +112,7 @@
        (map #(assoc % :get-site-data (gen-get-site-data site-data)))))
 
 (defn generate-debug-site-index
-  "Creates a map where the keys are URIs and the values are functions that log
+  "Creates a map where the keys are URLs and the values are functions that log
   the page map and return the page's Hiccup. This datastructure is
   defined by stasis."
   [{:keys [nuzzle/render-page] :as config}]
@@ -120,20 +120,20 @@
   (->> config
        generate-page-list
        (map (fn [page] (when-let [render-result (render-page page)]
-                         [(:uri page)
+                         [(:nuzzle/url page)
                           (fn [_]
                             (log/log-rendering-page page)
                             (hiccup/html-document render-result))])))
        (into {})))
 
 (defn generate-rendered-site-index
-  "Creates a map where the keys are relative URIs and the values are Hiccup.
+  "Creates a map where the keys are relative URLs and the values are Hiccup.
   This datastructure is defined by stasis."
   [{:keys [nuzzle/render-page] :as config}]
   {:pre [(fn? render-page)] :post [(map? %)]}
   (->> config
        generate-page-list
        (map (fn [page] (when-let [render-result (render-page page)]
-                         [(:uri page)
+                         [(:nuzzle/url page)
                           (hiccup/html-document render-result)])))
        (into {})))

--- a/src/nuzzle/rss.clj
+++ b/src/nuzzle/rss.clj
@@ -28,11 +28,11 @@
    :post [(string? %)]}
   (let [{:keys [link]} rss-channel
         rss-items
-        (for [{:keys [rss? uri] :as page} (vals site-data)
+        (for [{:nuzzle/keys [url] :keys [rss?] :as page} (vals site-data)
               :when rss?]
           (-> page
               (select-keys valid-item-tags)
-              (assoc :guid (str link uri))))]
+              (assoc :guid (str link url))))]
     (try (apply rss/channel-xml
                 rss-channel
                 rss-items)

--- a/src/nuzzle/sitemap.clj
+++ b/src/nuzzle/sitemap.clj
@@ -16,15 +16,15 @@
     {:tag :urlset
      :attrs {:xmlns "http://www.sitemaps.org/schemas/sitemap/0.9"}
      :content
-     (for [[uri _hiccup] rendered-site-index
-           :let [id (util/uri->id uri)
+     (for [[url _hiccup] rendered-site-index
+           :let [id (util/url->id url)
                  {:keys [modified]} (get site-data id)
-                 page-url (str base-url uri)]]
+                 url (str base-url url)]]
        {:tag :url
         :content
         (remove nil?
                 [{:tag :loc
-                  :content [page-url]}
+                  :content [url]}
                  (when modified
                    {:tag :lastmod
                     :content [(util/format-simple-date modified)]})])})}

--- a/src/nuzzle/util.clj
+++ b/src/nuzzle/util.clj
@@ -12,16 +12,16 @@
     (apply merge-with deep-merge a maps)
     (apply merge-with deep-merge maps)))
 
-(defn id->uri
+(defn id->url
   [id]
   {:pre [(vector? id)]}
   (if (= [] id) "/"
     (str "/" (string/join "/" (map name id)) "/")))
 
-(defn uri->id
-  [uri]
-  {:pre [(string? uri)]}
-  (->> (string/split uri #"/")
+(defn url->id
+  [url]
+  {:pre [(string? url)]}
+  (->> (string/split url #"/")
        (remove string/blank?)
        (map keyword)
        vec))

--- a/test/nuzzle/generator_test.clj
+++ b/test/nuzzle/generator_test.clj
@@ -61,36 +61,36 @@
             :when (vector? id)]
       (is (fn? (:render-content info))))
     (is (= {[]
-            {:uri "/"}
+            {:nuzzle/url "/"}
             [:blog :nuzzle-rocks]
             {:title "10 Reasons Why Nuzzle Rocks",
              :content "test-resources/markdown/nuzzle-rocks.md",
              :modified "2022-05-09"
              :rss? true
              :tags #{:nuzzle},
-             :uri "/blog/nuzzle-rocks/"}
+             :nuzzle/url "/blog/nuzzle-rocks/"}
             [:blog :why-nuzzle]
             {:title "Why I Made Nuzzle",
              :content "test-resources/markdown/why-nuzzle.md",
              :rss? true
              :tags #{:nuzzle},
-             :uri "/blog/why-nuzzle/"}
+             :nuzzle/url "/blog/why-nuzzle/"}
             [:blog :favorite-color]
             {:title "What's My Favorite Color? It May Suprise You.",
              :content "test-resources/markdown/favorite-color.md",
              :rss? true
              :tags #{:colors},
-             :uri "/blog/favorite-color/"}
+             :nuzzle/url "/blog/favorite-color/"}
             [:about]
             {:title "About",
              :content "test-resources/markdown/about.md",
-             :uri "/about/"}
+             :nuzzle/url "/about/"}
             :meta
             {:twitter "https://twitter/foobar"}}
            without-render-content))))
 
-(deftest id->uri
-  (is (= "/blog-posts/my-hobbies/" (util/id->uri [:blog-posts :my-hobbies])))
-  (is (= "/about/" (util/id->uri [:about]))))
+(deftest id->url
+  (is (= "/blog-posts/my-hobbies/" (util/id->url [:blog-posts :my-hobbies])))
+  (is (= "/about/" (util/id->url [:about]))))
 
 (comment (run-tests))

--- a/test/nuzzle/integration_test.clj
+++ b/test/nuzzle/integration_test.clj
@@ -86,21 +86,21 @@
           {[:blog-posts :defeating-misty]
            {:title "How I Defeated Misty with Pikachu",
             :content "test-resources/markdown/how-i-defeated-misty.md",
-            :uri "/blog-posts/defeating-misty/",
+            :nuzzle/url "/blog-posts/defeating-misty/",
             :render-content '([:h1 {:id "placeholder"} "Placeholder"])},
            []
            {:content "test-resources/markdown/homepage-introduction.md",
             :index #{[:about] [:blog-posts]},
-            :uri "/",
+            :nuzzle/url "/",
             :render-content '([:h1 {:id "placeholder"} "Placeholder"])},
            [:blog-posts :catching-pikachu]
            {:title "How I Caught Pikachu",
             :content "test-resources/markdown/how-i-caught-pikachu.md",
-            :uri "/blog-posts/catching-pikachu/",
+            :nuzzle/url "/blog-posts/catching-pikachu/",
             :render-content '([:h1 {:id "placeholder"} "Placeholder"])},
            [:about]
            {:content "test-resources/markdown/about-ash.md",
-            :uri "/about/",
+            :nuzzle/url "/about/",
             :render-content '([:h1 {:id "placeholder"} "Placeholder"])},
            :crypto
            {:bitcoin "1GVY5eZvtc5bA6EFEGnpqJeHUC5YaV5dsb",
@@ -110,5 +110,5 @@
            {:index
             #{[:blog-posts :defeating-misty] [:blog-posts :catching-pikachu]},
             :title "Blog Posts",
-            :uri "/blog-posts/",
+            :nuzzle/url "/blog-posts/",
             :render-content nil}}})))

--- a/test/nuzzle/util_test.clj
+++ b/test/nuzzle/util_test.clj
@@ -3,9 +3,9 @@
    [clojure.test :refer [deftest is]]
    [nuzzle.util :as util]))
 
-(deftest uri->id
+(deftest url->id
   (is (= (list [:about] [] [:blog-posts :foo])
-         (map util/uri->id ["/about/" "/" "/blog-posts/foo/"]))))
+         (map util/url->id ["/about/" "/" "/blog-posts/foo/"]))))
 
 (deftest format-simple-date
   (is (= "2016-04-03"


### PR DESCRIPTION
Adding the nuzzle namespace continues the theme of adding the namespace
to values in the config datastructure that Nuzzle specifies and uses
internally. The URL verbiage matches #1 and URL is a more familiar term
than URI.

Fixes #7