### PR TITLE
Rename :syntax-highlighting to :nuzzle/syntax-highlighter (#41)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,9 @@ Nuzzle expects to find an EDN map in the file `nuzzle.edn` in your current worki
 - `:nuzzle/publish-dir` - A path to a directory to publish the site into. Defaults to `"out"`.
 - `:nuzzle/overlay-dir` - A path to a directory that will be overlayed on top of the `:nuzzle/publish-dir` directory as the final stage of publishing. Defaults to `nil` (no overlay).
 - `:markdown-opts` - A map of markdown processing options (syntax highlighting)
-- `:nuzzle/rss-channel` - A map with an RSS channel specification. Defaults to nil (no RSS feed).
-- `:nuzzle/build-drafts?` - A boolean that indicates whether pages marked as a draft should be removed. Defaults to nil (no draft removal).
+- `:nuzzle/syntax-highlighter` - A map of syntax highlighting options for language-tagged code blocks. Defaults to `nil` (no syntax highlighting).
+- `:nuzzle/rss-channel` - A map with an RSS channel specification. Defaults to `nil` (no RSS feed).
+- `:nuzzle/build-drafts?` - A boolean that indicates whether pages marked as a draft should be included. Defaults to `nil` (no drafts included).
 - `:nuzzle/custom-elements` - A map of keywords -> symbols which define functions to transform the Hiccup representation of custom HTML elements.
 - `:nuzzle/server-port` - A port number for the development server to listen on. Defaults to 6899.
 
@@ -282,26 +283,15 @@ At the bottom of the function we can see the function from `:render-content` bei
 ## Generating an RSS feed
 Nuzzle comes with support for generating an RSS feed. (TODO)
 
-## Getting Fancy with Markdown
-You can configure how Nuzzle interprets your Markdown files with the top-level `:markdown-opts` map which has these keys:
-- `:syntax-highlighting` - A map of syntax highlighting options for code-blocks. Defaults to `nil` (no syntax highlighting).
-
-Here's an example:
-```
-{:syntax-highlighting
- {:provider :pygments
-  :style "algol_nu"}}
-```
-
-### Syntax Highlighting
+## Syntax Highlighting
 Syntax-highlighted code can give your website a polished, sophisticated appearance. Nuzzle let's you painlessly plug your Markdown code-blocks into [Pygments](https://github.com/pygments/pygments) or [Chroma](https://github.com/alecthomas/chroma). Nuzzle uses `clojure.java.sh/sh` to interact with these programs. Since they are not available as Java or Clojure libraries, Nuzzle users must manually install them into their $PATH in order for Nuzzle to use them.
 
-Syntax highlighting is controlled via the `:syntax-highlighting` map which has these keys:
+Syntax highlighting is controlled via the config setting `:nuzzle/syntax-highlighter` which is expected to be a map with these keys:
 - `:provider` - A keyword specifying the program to use (either `:chroma` or `:pygments`). Required.
 - `:style` - A string specifying a style for Markdown code syntax highlighting. Defaults to `nil` (HTML classes only).
 - `:line-numbers?` - A boolean indicating whether line numbers should be included.
 
-When this map is present, Nuzzle will run you code-blocks with language annotations through the chosen syntax-highlighting program. If the program supports the language found in the language annotation (check their lexers list), it will output the code as HTML with the different syntax tokens wrapped in `span` elements.
+When this map is present, Nuzzle will run you code-blocks with language annotations through the chosen syntax highlighting program. If the program supports the language found in the language annotation (check their lexers list), it will output the code as HTML with the different syntax tokens wrapped in `span` elements.
 
 If `:style` is `nil`, the programs will just attach classes to these `span` elements and it's up to you to define their CSS. If `:style` is specified, the programs will attempt to apply that style as inline CSS.
 

--- a/src/nuzzle/content.clj
+++ b/src/nuzzle/content.clj
@@ -56,14 +56,14 @@
 
 (defn generate-chroma-command
   [file-path language config]
-  (let [{:keys [style line-numbers?]} (get-in config [:markdown-opts :syntax-highlighting])]
+  (let [{:keys [style line-numbers?]} (:nuzzle/syntax-highlighter config)]
     ["chroma" (str "--lexer=" language) "--formatter=html" "--html-only"
      "--html-prevent-surrounding-pre" (when style "--html-inline-styles")
      (when style (str "--style=" style)) (when line-numbers? "--html-lines")  file-path]))
 
 (defn generate-pygments-command
   [file-path language config]
-  (let [{:keys [style line-numbers?]} (get-in config [:markdown-opts :syntax-highlighting])
+  (let [{:keys [style line-numbers?]} (:nuzzle/syntax-highlighter config)
         ;; TODO: turn nowrap on for everything if they release my PR
         ;; https://github.com/pygments/pygments/issues/2127
         options [(when-not line-numbers? "nowrap") (when style "noclasses")
@@ -75,7 +75,7 @@
 (defn generate-highlight-command
   [file-path language config]
   (->>
-   (case (get-in config [:markdown-opts :syntax-highlighting :provider])
+   (case (get-in config [:nuzzle/syntax-highlighter :provider])
     :chroma (generate-chroma-command file-path language config)
     :pygments (generate-pygments-command file-path language config))
    (remove nil?)))
@@ -96,7 +96,7 @@
         out))))
 
 (defn code-block->hiccup [[_tag-name {:keys [language]} code] config]
-  (if (and language (get-in config [:markdown-opts :syntax-highlighting]))
+  (if (and language (:nuzzle/syntax-highlighter config))
     [:pre
      [:code.code-block (hiccup/raw (highlight-code code language config))]]
     [:pre [:code.code-block code]]))

--- a/src/nuzzle/schemas.clj
+++ b/src/nuzzle/schemas.clj
@@ -25,14 +25,14 @@
 (def markdown-opts
   [:map
    {:optional true
-    :closed true}
-   [:syntax-highlighting
-    {:optional true}
-    [:map
-     ;; TODO: Add option to specify custom highlighting command
-     [:provider [:enum :chroma :pygments]]
-     [:style {:optional true} [:or :string :nil]]
-     [:line-numbers? {:optional true} :boolean]]]])
+    :closed true}])
+
+(def syntax-highlighter
+  [:map
+   ;; TODO: Add option to specify custom highlighting command
+   [:provider [:enum :chroma :pygments]]
+   [:style {:optional true} [:or :string :nil]]
+   [:line-numbers? {:optional true} :boolean]])
 
 (def base-url
   [:and
@@ -47,6 +47,7 @@
    [:nuzzle/render-page fn?]
    [:nuzzle/base-url base-url]
    [:markdown-opts {:optional true} markdown-opts]
+   [:nuzzle/syntax-highlighter {:optional true} syntax-highlighter]
    [:nuzzle/custom-elements {:optional true} [:map-of :keyword :symbol]]
    [:nuzzle/overlay-dir {:optional true} string?]
    [:nuzzle/publish-dir {:optional true} string?]

--- a/test/nuzzle/content_test.clj
+++ b/test/nuzzle/content_test.clj
@@ -22,45 +22,45 @@
 (deftest generate-highlight-command
   (testing "generating chroma command"
     (is (= (list "chroma" "--lexer=clojure" "--formatter=html" "--html-only" "--html-prevent-surrounding-pre" "/tmp/foo.clj")
-           (con/generate-highlight-command "/tmp/foo.clj" "clojure" {:markdown-opts {:syntax-highlighting {:provider :chroma}}})))
+           (con/generate-highlight-command "/tmp/foo.clj" "clojure" {:nuzzle/syntax-highlighter {:provider :chroma}})))
     (is (= (list "chroma" "--lexer=clojure" "--formatter=html" "--html-only" "--html-prevent-surrounding-pre" "--html-lines" "/tmp/foo.clj")
-           (con/generate-highlight-command "/tmp/foo.clj" "clojure" {:markdown-opts {:syntax-highlighting {:provider :chroma :line-numbers? true}}})))
+           (con/generate-highlight-command "/tmp/foo.clj" "clojure" {:nuzzle/syntax-highlighter {:provider :chroma :line-numbers? true}})))
     (is (= (list "chroma" "--lexer=clojure" "--formatter=html" "--html-only" "--html-prevent-surrounding-pre" "--html-inline-styles" "--style=algol_nu" "/tmp/foo.clj")
-           (con/generate-highlight-command "/tmp/foo.clj" "clojure" {:markdown-opts {:syntax-highlighting {:provider :chroma :style "algol_nu"}}})))
+           (con/generate-highlight-command "/tmp/foo.clj" "clojure" {:nuzzle/syntax-highlighter {:provider :chroma :style "algol_nu"}})))
     (is (= (list "chroma" "--lexer=clojure" "--formatter=html" "--html-only" "--html-prevent-surrounding-pre" "--html-inline-styles" "--style=algol_nu" "--html-lines" "/tmp/foo.clj")
-           (con/generate-highlight-command "/tmp/foo.clj" "clojure" {:markdown-opts {:syntax-highlighting {:provider :chroma :style "algol_nu" :line-numbers? true}}}))))
+           (con/generate-highlight-command "/tmp/foo.clj" "clojure" {:nuzzle/syntax-highlighter {:provider :chroma :style "algol_nu" :line-numbers? true}}))))
   (testing "generating pygments command"
     (is (= (list "pygmentize" "-f" "html" "-l" "clojure" "-O" "nowrap" "/tmp/foo.clj")
-           (con/generate-highlight-command "/tmp/foo.clj" "clojure" {:markdown-opts {:syntax-highlighting {:provider :pygments}}})))
+           (con/generate-highlight-command "/tmp/foo.clj" "clojure" {:nuzzle/syntax-highlighter {:provider :pygments}})))
     (is (= (list "pygmentize" "-f" "html" "-l" "clojure" "-O" "linenos=inline"  "/tmp/foo.clj")
-           (con/generate-highlight-command "/tmp/foo.clj" "clojure" {:markdown-opts {:syntax-highlighting {:provider :pygments :line-numbers? true}}})))
+           (con/generate-highlight-command "/tmp/foo.clj" "clojure" {:nuzzle/syntax-highlighter {:provider :pygments :line-numbers? true}})))
     (is (= (list "pygmentize" "-f" "html" "-l" "clojure" "-O" "nowrap,noclasses,style=algol_nu" "/tmp/foo.clj")
-           (con/generate-highlight-command "/tmp/foo.clj" "clojure" {:markdown-opts {:syntax-highlighting {:provider :pygments :style "algol_nu"}}})))
+           (con/generate-highlight-command "/tmp/foo.clj" "clojure" {:nuzzle/syntax-highlighter {:provider :pygments :style "algol_nu"}})))
     (is (= (list "pygmentize" "-f" "html" "-l" "clojure" "-O" "noclasses,style=algol_nu,linenos=inline" "/tmp/foo.clj")
-           (con/generate-highlight-command "/tmp/foo.clj" "clojure" {:markdown-opts {:syntax-highlighting {:provider :pygments :style "algol_nu" :line-numbers? true}}})))))
+           (con/generate-highlight-command "/tmp/foo.clj" "clojure" {:nuzzle/syntax-highlighter {:provider :pygments :style "algol_nu" :line-numbers? true}})))))
 
 ;; (deftest highlight-code
 ;;   (let [code "(def foo (let [x (+ 5 7)] (println x)))"]
 ;;     ;; Chroma 2.2.0
 ;;     (testing "chroma HTML output"
 ;;       (is (= "<span class=\"p\">(</span><span class=\"k\">def </span><span class=\"nv\">foo</span> <span class=\"p\">(</span><span class=\"k\">let </span><span class=\"p\">[</span><span class=\"nv\">x</span> <span class=\"p\">(</span><span class=\"nb\">+ </span><span class=\"mi\">5</span> <span class=\"mi\">7</span><span class=\"p\">)]</span> <span class=\"p\">(</span><span class=\"nb\">println </span><span class=\"nv\">x</span><span class=\"p\">)))</span>"
-;;              (con/highlight-code code "clojure" {:markdown-opts {:syntax-highlighting {:provider :chroma}}})))
+;;              (con/highlight-code code "clojure" {:nuzzle/syntax-highlighter {:provider :chroma}})))
 ;;       (is (= "(<span style=\"color:#fb660a;font-weight:bold\">def </span><span style=\"color:#fb660a\">foo</span> (<span style=\"color:#fb660a;font-weight:bold\">let </span>[<span style=\"color:#fb660a\">x</span> (+ <span style=\"color:#0086f7;font-weight:bold\">5</span> <span style=\"color:#0086f7;font-weight:bold\">7</span>)] (println <span style=\"color:#fb660a\">x</span>)))"
-;;              (con/highlight-code code "clojure" {:markdown-opts {:syntax-highlighting {:provider :chroma :style "fruity"}}})))
+;;              (con/highlight-code code "clojure" {:nuzzle/syntax-highlighter {:provider :chroma :style "fruity"}})))
 ;;       (is (= "<span class=\"p\">(</span><span class=\"k\">def </span><span class=\"nv\">foo</span> <span class=\"p\">(</span><span class=\"k\">let </span><span class=\"p\">[</span><span class=\"nv\">x</span> <span class=\"p\">(</span><span class=\"nb\">+ </span><span class=\"mi\">5</span> <span class=\"mi\">7</span><span class=\"p\">)]</span> <span class=\"p\">(</span><span class=\"nb\">println </span><span class=\"nv\">x</span><span class=\"p\">)))</span>"
-;;              (con/highlight-code code "clojure" {:markdown-opts {:syntax-highlighting {:provider :chroma :line-numbers? true}}})))
+;;              (con/highlight-code code "clojure" {:nuzzle/syntax-highlighter {:provider :chroma :line-numbers? true}})))
 ;;       (is (= "(<span style=\"color:#fb660a;font-weight:bold\">def </span><span style=\"color:#fb660a\">foo</span> (<span style=\"color:#fb660a;font-weight:bold\">let </span>[<span style=\"color:#fb660a\">x</span> (+ <span style=\"color:#0086f7;font-weight:bold\">5</span> <span style=\"color:#0086f7;font-weight:bold\">7</span>)] (println <span style=\"color:#fb660a\">x</span>)))"
-;;              (con/highlight-code code "clojure" {:markdown-opts {:syntax-highlighting {:provider :chroma :style "fruity" :line-numbers? true}}}))))
+;;              (con/highlight-code code "clojure" {:nuzzle/syntax-highlighter {:provider :chroma :style "fruity" :line-numbers? true}}))))
 ;;     ;; Pygmentize 2.12.0
 ;;     (testing "pygments HTML output"
 ;;       (is (= "<span class=\"p\">(</span><span class=\"k\">def </span><span class=\"nv\">foo</span><span class=\"w\"> </span><span class=\"p\">(</span><span class=\"k\">let </span><span class=\"p\">[</span><span class=\"nv\">x</span><span class=\"w\"> </span><span class=\"p\">(</span><span class=\"nb\">+ </span><span class=\"mi\">5</span><span class=\"w\"> </span><span class=\"mi\">7</span><span class=\"p\">)]</span><span class=\"w\"> </span><span class=\"p\">(</span><span class=\"nb\">println </span><span class=\"nv\">x</span><span class=\"p\">)))</span><span class=\"w\"></span>\n"
-;;              (con/highlight-code code "clojure" {:markdown-opts {:syntax-highlighting {:provider :pygments}}})))
+;;              (con/highlight-code code "clojure" {:nuzzle/syntax-highlighter {:provider :pygments}})))
 ;;
 ;;       (is (= "<span style=\"color: #ffffff\">(</span><span style=\"color: #fb660a; font-weight: bold\">def </span><span style=\"color: #fb660a\">foo</span><span style=\"color: #888888\"> </span><span style=\"color: #ffffff\">(</span><span style=\"color: #fb660a; font-weight: bold\">let </span><span style=\"color: #ffffff\">[</span><span style=\"color: #fb660a\">x</span><span style=\"color: #888888\"> </span><span style=\"color: #ffffff\">(+ </span><span style=\"color: #0086f7; font-weight: bold\">5</span><span style=\"color: #888888\"> </span><span style=\"color: #0086f7; font-weight: bold\">7</span><span style=\"color: #ffffff\">)]</span><span style=\"color: #888888\"> </span><span style=\"color: #ffffff\">(println </span><span style=\"color: #fb660a\">x</span><span style=\"color: #ffffff\">)))</span><span style=\"color: #888888\"></span>\n"
-;;              (con/highlight-code code "clojure" {:markdown-opts {:syntax-highlighting {:provider :pygments :style "fruity"}}})))
+;;              (con/highlight-code code "clojure" {:nuzzle/syntax-highlighter {:provider :pygments :style "fruity"}})))
 ;;
-;;       (is (= (con/highlight-code "(def foo (let [x (+ 5 7)] (println x)))" "clojure" {:markdown-opts {:syntax-highlighting {:provider :pygments :line-numbers? true}}})
-;;              (con/highlight-code code "clojure" {:markdown-opts {:syntax-highlighting {:provider :pygments :line-numbers? true}}}))))))
+;;       (is (= (con/highlight-code "(def foo (let [x (+ 5 7)] (println x)))" "clojure" {:nuzzle/syntax-highlighter {:provider :pygments :line-numbers? true}})
+;;              (con/highlight-code code "clojure" {:nuzzle/syntax-highlighter {:provider :pygments :line-numbers? true}}))))))
 
 (deftest create-render-content-fn
   (let [{:keys [content]} (get-in (config) [:site-data [:about]])
@@ -90,5 +90,5 @@
            expected-result))))
 
 (comment ((con/create-render-content-fn [:inline-html] "test-resources/markdown/inline-html.md" nil))
-         (con/highlight-code "(defn hi [] \"hi\")" "clojure" {:markdown-opts {:syntax-highlighting {:provider :pygments :line-numbers? true}}})
+         (con/highlight-code "(defn hi [] \"hi\")" "clojure" {:nuzzle/syntax-highlighter {:provider :pygments :line-numbers? true}})
          (run-tests))

--- a/test/nuzzle/schemas_test.clj
+++ b/test/nuzzle/schemas_test.clj
@@ -5,11 +5,10 @@
    [malli.transform :as mt]
    [nuzzle.schemas :as schemas]))
 
-(deftest markdown
-  (is (m/validate schemas/markdown-opts
-                  {:syntax-highlighting
-                   {:provider :chroma
-                    :style "emacs"}})))
+(deftest syntax-highlighter
+  (is (m/validate schemas/syntax-highlighter
+                  {:provider :chroma
+                   :style "emacs"})))
 
 (deftest local-date
   (is (m/validate schemas/local-date


### PR DESCRIPTION
Also pull it to the top-level of the config.

Fixes #41 