### PR TITLE
Remove :markdown-opts config key (#43)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ Nuzzle expects to find an EDN map in the file `nuzzle.edn` in your current worki
 - `:nuzzle/render-page` - A fully qualified symbol pointing to your page rendering function. Required.
 - `:nuzzle/publish-dir` - A path to a directory to publish the site into. Defaults to `"out"`.
 - `:nuzzle/overlay-dir` - A path to a directory that will be overlayed on top of the `:nuzzle/publish-dir` directory as the final stage of publishing. Defaults to `nil` (no overlay).
-- `:markdown-opts` - A map of markdown processing options (syntax highlighting)
 - `:nuzzle/syntax-highlighter` - A map of syntax highlighting options for language-tagged code blocks. Defaults to `nil` (no syntax highlighting).
 - `:nuzzle/rss-channel` - A map with an RSS channel specification. Defaults to `nil` (no RSS feed).
 - `:nuzzle/build-drafts?` - A boolean that indicates whether pages marked as a draft should be included. Defaults to `nil` (no drafts included).

--- a/src/nuzzle/schemas.clj
+++ b/src/nuzzle/schemas.clj
@@ -22,11 +22,6 @@
      (fn [{:keys [rss? title description]}]
        (or (not rss?) (or title description)))]]])
 
-(def markdown-opts
-  [:map
-   {:optional true
-    :closed true}])
-
 (def syntax-highlighter
   [:map
    ;; TODO: Add option to specify custom highlighting command
@@ -46,7 +41,6 @@
    [:site-data site-data]
    [:nuzzle/render-page fn?]
    [:nuzzle/base-url base-url]
-   [:markdown-opts {:optional true} markdown-opts]
    [:nuzzle/syntax-highlighter {:optional true} syntax-highlighter]
    [:nuzzle/custom-elements {:optional true} [:map-of :keyword :symbol]]
    [:nuzzle/overlay-dir {:optional true} string?]


### PR DESCRIPTION
The :markdown-opts config option no longer had anything in it and was
vestigial. It is finally removed in this patch.

Fixes #43 