### PR TITLE
Swap Malli for clojure.spec for config validation (#45)

### DIFF
--- a/src/nuzzle/util.clj
+++ b/src/nuzzle/util.clj
@@ -78,9 +78,10 @@
         {})))
 
 (defn format-simple-date [date]
-  {:pre [(instance? java.time.temporal.Temporal date)]}
   (let [fmt (java.time.format.DateTimeFormatter/ofPattern "yyyy-MM-dd")]
-    (.format fmt date)))
+    (if (instance? java.time.temporal.Temporal date)
+      (.format fmt date)
+      date)))
 
 (defn find-hiccup-str
   "Find first string matching regular expression in deeply nested Hiccup tree"

--- a/test/nuzzle/config_test.clj
+++ b/test/nuzzle/config_test.clj
@@ -7,25 +7,13 @@
 
 (def render-page (constantly [:h1 "test"]))
 
-(deftest decode-config
-  (is (= {:nuzzle/render-page render-page
-          :nuzzle/base-url "http://foobar.com"
-          :site-data #{{:id []
-                        :modified (java.time.LocalDate/parse "2022-05-09")}}}
-         (conf/decode-config
-          {:nuzzle/render-page render-page
-           :nuzzle/base-url "http://foobar.com"
-           :site-data #{{:id []
-                         :modified "2022-05-09"}}}))))
-
-(deftest read-specified-config
-  (is (= (conf/read-specified-config config-path {})
+(deftest read-config-path
+  (is (= (conf/read-config-path config-path)
          {:nuzzle/publish-dir "/tmp/nuzzle-test-out",
-          :nuzzle/server-port 6899,
           :nuzzle/base-url "https://foobar.com"
           :nuzzle/sitemap? true
           :nuzzle/build-drafts? true,
-          :nuzzle/render-page render-page,
+          :nuzzle/render-page 'nuzzle.config-test/render-page,
           :nuzzle/rss-channel
           {:title "Foo's blog",
            :description "Rants about foo and thoughts about bar",

--- a/test/nuzzle/generator_test.clj
+++ b/test/nuzzle/generator_test.clj
@@ -6,7 +6,7 @@
 
 (def config-path "test-resources/edn/config-1.edn")
 
-(defn config [] (conf/read-specified-config config-path {}))
+(defn config [] (conf/read-config-path config-path))
 
 (defn site-data [] (:site-data (config)))
 

--- a/test/nuzzle/schemas_test.clj
+++ b/test/nuzzle/schemas_test.clj
@@ -1,19 +1,14 @@
-(ns nuzzle.schemas-test
-  (:require
-   [clojure.test :refer [deftest is]]
-   [malli.core :as m]
-   [malli.transform :as mt]
-   [nuzzle.schemas :as schemas]))
+(ns nuzzle.schemas-test)
 
-(deftest syntax-highlighter
-  (is (m/validate schemas/syntax-highlighter
-                  {:provider :chroma
-                   :style "emacs"})))
-
-(deftest local-date
-  (is (m/validate schemas/local-date
-                  (m/decode schemas/local-date "2022-05-04"
-                            (mt/transformer {:name :local-date}))))
-  (is (not (m/validate schemas/local-date
-                       (m/decode schemas/local-date "2022-05-04jhfklsdjf"
-                                 (mt/transformer {:name :local-date}))))))
+;; (deftest syntax-highlighter
+;;   (is (m/validate schemas/syntax-highlighter
+;;                   {:provider :chroma
+;;                    :style "emacs"})))
+;;
+;; (deftest local-date
+;;   (is (m/validate schemas/local-date
+;;                   (m/decode schemas/local-date "2022-05-04"
+;;                             (mt/transformer {:name :local-date}))))
+;;   (is (not (m/validate schemas/local-date
+;;                        (m/decode schemas/local-date "2022-05-04jhfklsdjf"
+;;                                  (mt/transformer {:name :local-date}))))))


### PR DESCRIPTION
Malli cannot properly express the spec for the upcoming shape of the
config with the page entries intermingled with the top-level config
options. Switching to clojure.spec allows the new config shape to have
great error messages all around. Malli's error messages using :and :map
:fn are very limited.

Fixes #45 