### PR TITLE
Remove :site-data, merge into top-level config (#5)

### DIFF
--- a/src/nuzzle/api.clj
+++ b/src/nuzzle/api.clj
@@ -1,17 +1,17 @@
 (ns nuzzle.api
   (:require [nuzzle.config :as conf]
+            [nuzzle.generator :as gen]
             [nuzzle.publish :as publish]
             [nuzzle.log :as log]
-            [nuzzle.ring :as ring]
-            [nuzzle.util :as util]))
+            [nuzzle.ring :as ring]))
 
 (defn realize
   "Allows the user to visualize the site data after Nuzzle's modifications."
   [& {:as config-overrides}]
   {:pre [(or (nil? config-overrides) (map? config-overrides))]}
   (let [config (conf/load-default-config config-overrides)]
-    (log/info "🔍🐈 Printing realized site data for inspection")
-    (util/convert-site-data-to-set config)))
+    (log/info "🔍🐈 Printing realized config for inspection")
+    (-> config gen/realize-config)))
 
 (defn publish
   "Publishes the website to :nuzzle/publish-dir. The overlay directory is

--- a/src/nuzzle/config.clj
+++ b/src/nuzzle/config.clj
@@ -48,7 +48,7 @@
                    (assoc :nuzzle/render-page render-page-fn))]
     (reduce-kv
      (fn [acc k v]
-       (if-not (and (vector? k) (map? v))
+       (if-not (map? v)
          (assoc acc k v)
          (assoc acc k
                 (cond-> v
@@ -56,15 +56,15 @@
      {} config)))
 
 (defn load-specified-config
-  "Read the site-data EDN file and validate it."
-  [config-path config-overrides]
+  "Read a config EDN file and validate it."
+  [config-path & {:as config-overrides}]
   (-> config-path
       read-config-path
       validate-config
       (transform-config config-overrides)
-      (gen/realize-site-data)))
+      (gen/realize-config)))
 
-(defn load-default-config [config-overrides]
+(defn load-default-config [& {:as config-overrides}]
   (load-specified-config "nuzzle.edn" config-overrides))
 
-(comment (load-specified-config "test-resources/config-1.edn" {}))
+(comment (load-specified-config "test-resources/edn/config-1.edn" {}))

--- a/src/nuzzle/rss.clj
+++ b/src/nuzzle/rss.clj
@@ -23,14 +23,15 @@
 (defn create-rss-feed
   "Creates a string of XML that is a valid RSS feed"
   ;; TODO: make sure that clj-rss baked in PermaLink=false is ok
-  [{:nuzzle/keys [rss-channel] :keys [site-data] :as _config}]
-  {:pre [(map? site-data) (map? rss-channel)]
+  [{:nuzzle/keys [rss-channel] :as config}]
+  {:pre [(map? rss-channel)]
    :post [(string? %)]}
   (let [{:keys [link]} rss-channel
         rss-items
-        (for [{:nuzzle/keys [url] :keys [rss?] :as page} (vals site-data)
-              :when rss?]
-          (-> page
+        (for [[ckey cval] config
+              :let [{:nuzzle/keys [url] :keys [rss?]} cval]
+              :when (and (vector? ckey) rss?)]
+          (-> cval
               (select-keys valid-item-tags)
               (assoc :guid (str link url))))]
     (try (apply rss/channel-xml

--- a/src/nuzzle/schemas.clj
+++ b/src/nuzzle/schemas.clj
@@ -32,7 +32,7 @@
 
 ;; Config Rules
 (s/def :nuzzle/page-key (s/coll-of keyword? :kind vector?))
-(s/def :nuzzle/page-map (s/keys :req [:nuzzle/title] :opt [:nuzzle/rss? :nuzzle/modified :nuzzle/tags]))
+(s/def :nuzzle/page-map (s/keys :req-un [:nuzzle/title] :opt-un [:nuzzle/rss? :nuzzle/modified :nuzzle/tags]))
 (s/def :nuzzle/config-entry (s/or :page (s/tuple :nuzzle/page-key :nuzzle/page-map)
                                   :option (s/tuple keyword? any?)))
 

--- a/src/nuzzle/sitemap.clj
+++ b/src/nuzzle/sitemap.clj
@@ -11,14 +11,14 @@
 (defn create-sitemap
   "Assumes realized site data is in map form and that drafts have already been
   removed from rendered-site-index."
-  [{:keys [site-data nuzzle/base-url] :as _config} rendered-site-index]
+  [{:nuzzle/keys [base-url] :as config} rendered-site-index]
    (xml/emit-str
     {:tag :urlset
      :attrs {:xmlns "http://www.sitemaps.org/schemas/sitemap/0.9"}
      :content
      (for [[url _hiccup] rendered-site-index
            :let [id (util/url->id url)
-                 {:keys [modified]} (get site-data id)
+                 {:keys [modified]} (get config id)
                  url (str base-url url)]]
        {:tag :url
         :content

--- a/src/nuzzle/util.clj
+++ b/src/nuzzle/util.clj
@@ -4,7 +4,10 @@
    [clj-commons.digest :as digest]
    [clojure.data :as data]
    [clojure.java.shell :as sh]
+   [clojure.pprint :as pprint]
    [clojure.string :as string]))
+
+(defn spy [x] (pprint/pprint x) x)
 
 ;; Taken from https://clojuredocs.org/clojure.core/merge
 (defn deep-merge [a & maps]
@@ -58,24 +61,6 @@
   (try (apply sh/sh command (remove nil? args))
     (catch Exception _
       {:exit 1 :err (str "Command failed. Please ensure " command " is installed.")})))
-
-(defn convert-site-data-to-set
-  [site-data]
-  {:pre [(map? site-data)] :post [#(set? %)]}
-  (->> site-data
-       (reduce-kv
-        (fn [agg id m]
-          (conj agg (assoc m :id id)))
-        #{})))
-
-(defn convert-site-data-to-map
-  [site-data]
-  {:pre [(or (seq? site-data) (set? site-data))] :post [#(map? %)]}
-  (->> site-data
-       (reduce
-        (fn [agg {:keys [id] :as m}]
-          (assoc agg id (dissoc m :id)))
-        {})))
 
 (defn format-simple-date [date]
   (let [fmt (java.time.format.DateTimeFormatter/ofPattern "yyyy-MM-dd")]

--- a/test-resources/edn/config-1.edn
+++ b/test-resources/edn/config-1.edn
@@ -2,37 +2,37 @@
  :nuzzle/base-url "https://foobar.com"
  :nuzzle/render-page nuzzle.config-test/render-page
  :nuzzle/rss-channel {:title "Foo's blog"
-               :description "Rants about foo and thoughts about bar"
-               :link "https://foobar.com"}
+                      :description "Rants about foo and thoughts about bar"
+                      :link "https://foobar.com"}
  :nuzzle/sitemap? true
  :nuzzle/overlay-dir "public"
  :nuzzle/publish-dir "/tmp/nuzzle-test-out"
- :site-data
- #{{:id []}
 
-   {:id [:blog :nuzzle-rocks]
-    :title "10 Reasons Why Nuzzle Rocks"
-    :content "test-resources/markdown/nuzzle-rocks.md"
-    :modified "2022-05-09"
-    :rss? true
-    :tags #{:nuzzle}}
+ [] {:title "Home"}
 
-   {:id [:blog :why-nuzzle]
-    :title "Why I Made Nuzzle"
-    :content "test-resources/markdown/why-nuzzle.md"
-    :rss? true
-    :tags #{:nuzzle}}
+ [:blog :nuzzle-rocks]
+ {:title "10 Reasons Why Nuzzle Rocks"
+  :content "test-resources/markdown/nuzzle-rocks.md"
+  :modified "2022-05-09"
+  :rss? true
+  :tags #{:nuzzle}}
 
-   {:id [:blog :favorite-color]
-    :title "What's My Favorite Color? It May Suprise You."
-    :content "test-resources/markdown/favorite-color.md"
-    :rss? true
-    :tags #{:colors}}
+ [:blog :why-nuzzle]
+ {:title "Why I Made Nuzzle"
+  :content "test-resources/markdown/why-nuzzle.md"
+  :rss? true
+  :tags #{:nuzzle}}
 
-   {:id [:about]
-    :title "About"
-    :content "test-resources/markdown/about.md"}
+ [:blog :favorite-color]
+ {:title "What's My Favorite Color? It May Suprise You."
+  :content "test-resources/markdown/favorite-color.md"
+  :rss? true
+  :tags #{:colors}}
 
-   {:id :meta
-    :twitter "https://twitter/foobar"}}}
+ [:about]
+ {:title "About"
+  :content "test-resources/markdown/about.md"}
+
+ :meta
+ {:twitter "https://twitter/foobar"}}
 

--- a/test/nuzzle/config_test.clj
+++ b/test/nuzzle/config_test.clj
@@ -14,31 +14,24 @@
           :nuzzle/sitemap? true
           :nuzzle/build-drafts? true,
           :nuzzle/render-page 'nuzzle.config-test/render-page,
-          :nuzzle/rss-channel
-          {:title "Foo's blog",
-           :description "Rants about foo and thoughts about bar",
-           :link "https://foobar.com"}
+          :nuzzle/rss-channel {:title "Foo's blog",
+                               :description "Rants about foo and thoughts about bar",
+                               :link "https://foobar.com"}
           :nuzzle/overlay-dir "public",
-          :site-data
-          #{{:id []}
-            {:id [:blog :nuzzle-rocks],
-             :title "10 Reasons Why Nuzzle Rocks",
-             :content "test-resources/markdown/nuzzle-rocks.md",
-             :modified "2022-05-09"
-             :rss? true,
-             :tags #{:nuzzle}}
-            {:id [:blog :why-nuzzle],
-             :title "Why I Made Nuzzle",
-             :content "test-resources/markdown/why-nuzzle.md",
-             :rss? true,
-             :tags #{:nuzzle}}
-            {:id [:blog :favorite-color],
-             :title "What's My Favorite Color? It May Suprise You.",
-             :content "test-resources/markdown/favorite-color.md",
-             :rss? true,
-             :tags #{:colors}}
-            {:id [:about],
-             :title "About",
-             :content "test-resources/markdown/about.md"}
-            {:id :meta, :twitter "https://twitter/foobar"}}})))
+          :meta {:twitter "https://twitter/foobar"},
+          [] {:title "Home"},
+          [:about] {:content "test-resources/markdown/about.md", :title "About"},
+          [:blog :favorite-color] {:content "test-resources/markdown/favorite-color.md",
+                                   :rss? true,
+                                   :tags #{:colors},
+                                   :title "What's My Favorite Color? It May Suprise You."},
+          [:blog :nuzzle-rocks] {:content "test-resources/markdown/nuzzle-rocks.md",
+                                 :modified "2022-05-09",
+                                 :rss? true,
+                                 :tags #{:nuzzle},
+                                 :title "10 Reasons Why Nuzzle Rocks"},
+          [:blog :why-nuzzle] {:content "test-resources/markdown/why-nuzzle.md",
+                               :rss? true,
+                               :tags #{:nuzzle},
+                               :title "Why I Made Nuzzle"}})))
 

--- a/test/nuzzle/content_test.clj
+++ b/test/nuzzle/content_test.clj
@@ -63,7 +63,7 @@
 ;;              (con/highlight-code code "clojure" {:nuzzle/syntax-highlighter {:provider :pygments :line-numbers? true}}))))))
 
 (deftest create-render-content-fn
-  (let [{:keys [content]} (get-in (config) [:site-data [:about]])
+  (let [{:keys [content]} (get (config) [:about])
         render-content (con/create-render-content-fn [:about] content nil)]
     (is (fn? render-content))
     (is (= (list [:h1 {:id "about"} "About"] [:p {} "This is a site for testing the Clojure static site generator called Nuzzle."])

--- a/test/nuzzle/generator_test.clj
+++ b/test/nuzzle/generator_test.clj
@@ -8,10 +8,6 @@
 
 (defn config [] (conf/read-config-path config-path))
 
-(defn site-data [] (:site-data (config)))
-
-(defn site-data-map [] (util/convert-site-data-to-map (site-data)))
-
 (deftest create-tag-index
   (is (= {[:tags :bar]
           {:index #{[:blog :foo]},
@@ -19,14 +15,14 @@
           [:tags :baz]
           {:index #{[:blog :foo]},
            :title "#baz"}}
-         (gen/create-tag-index {[:blog :foo] {:tags #{:bar :baz}} [:about] {} }) ))
+         (gen/create-tag-index {[:blog :foo] {:tags #{:bar :baz}} [:about] {}})))
   (is (= {[:tags :nuzzle]
           {:index #{[:blog :nuzzle-rocks] [:blog :why-nuzzle]},
            :title "#nuzzle"}
           [:tags :colors]
           {:index #{[:blog :favorite-color]},
            :title "#colors"}}
-         (gen/create-tag-index (site-data-map)))))
+         (gen/create-tag-index (config)))))
 
 (deftest create-group-index
   (is (= {[:blog-posts]
@@ -37,7 +33,8 @@
           [:projects]
           {:index #{[:projects :bee]}, :title "Projects"}
           []
-          {:index #{[:blog-posts] [:projects]}}}
+          {:index #{[:blog-posts] [:projects]}
+           :title "Home"}}
          (gen/create-group-index {[:blog-posts :foo] {:title "Foo"}
                                   [:blog-posts :archive :baz] {:title "Baz"}
                                   [:projects :bee] {:title "Bee"}})))
@@ -46,48 +43,9 @@
            #{[:blog :why-nuzzle] [:blog :favorite-color] [:blog :nuzzle-rocks]},
            :title "Blog"}
           []
-          {:index #{[:about] [:blog]}}}
-         (gen/create-group-index (site-data-map)))))
-
-(deftest realize-pages
-  (let [mod-site-data (-> (config)
-                          (update :site-data util/convert-site-data-to-map)
-                          (gen/realize-pages)
-                          (:site-data))
-        without-render-content (reduce-kv #(assoc %1 %2 (dissoc %3 :nuzzle/render-content))
-                                          {}
-                                          mod-site-data)]
-    (doseq [[id info] mod-site-data
-            :when (vector? id)]
-      (is (fn? (:nuzzle/render-content info))))
-    (is (= {[]
-            {:nuzzle/url "/"}
-            [:blog :nuzzle-rocks]
-            {:title "10 Reasons Why Nuzzle Rocks",
-             :content "test-resources/markdown/nuzzle-rocks.md",
-             :modified "2022-05-09"
-             :rss? true
-             :tags #{:nuzzle},
-             :nuzzle/url "/blog/nuzzle-rocks/"}
-            [:blog :why-nuzzle]
-            {:title "Why I Made Nuzzle",
-             :content "test-resources/markdown/why-nuzzle.md",
-             :rss? true
-             :tags #{:nuzzle},
-             :nuzzle/url "/blog/why-nuzzle/"}
-            [:blog :favorite-color]
-            {:title "What's My Favorite Color? It May Suprise You.",
-             :content "test-resources/markdown/favorite-color.md",
-             :rss? true
-             :tags #{:colors},
-             :nuzzle/url "/blog/favorite-color/"}
-            [:about]
-            {:title "About",
-             :content "test-resources/markdown/about.md",
-             :nuzzle/url "/about/"}
-            :meta
-            {:twitter "https://twitter/foobar"}}
-           without-render-content))))
+          {:index #{[:about] [:blog]}
+           :title "Home"}}
+         (gen/create-group-index (config)))))
 
 (deftest id->url
   (is (= "/blog-posts/my-hobbies/" (util/id->url [:blog-posts :my-hobbies])))

--- a/test/nuzzle/sitemap_test.clj
+++ b/test/nuzzle/sitemap_test.clj
@@ -16,8 +16,7 @@
          (sitemap/create-sitemap (config) (gen/generate-rendered-site-index (config)))))
   (is (= "<?xml version=\"1.0\" encoding=\"UTF-8\"?><urlset xmlns:a=\"http://www.sitemaps.org/schemas/sitemap/0.9\"><url><loc>https://foo.com/</loc></url><url><loc>https://foo.com/about/</loc><lastmod>2022-05-09</lastmod></url><url><loc>https://foo.com/blog-posts/foobar/</loc></url></urlset>"
          (sitemap/create-sitemap {:nuzzle/base-url "https://foo.com"
-                                  :site-data {[:about]
-                                              {:modified (java.time.LocalDate/parse "2022-05-09")}}}
+                                  [:about] {:modified (java.time.LocalDate/parse "2022-05-09")}}
                                  {"/" []
                                   "/about/" []
                                   "/blog-posts/foobar/" []}))))


### PR DESCRIPTION
Previously all page entries in the config map were stored inside a set
under the key :site-data. This change takes all the page entries in that
site-data set and lifts them to the top level of the config map with a
key of the page's :id value. This simplifies the config map greatly.

A ramification of this change is that the name get-site-data no longer
makes sense. This function has been changed to get-config and can be
used to get any value from the config map, making it even more useful.

Fixes #5 