### PR TITLE
Add bhb/expound for pretty spec error output (#67)

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -10,6 +10,7 @@
  :deps {clj-rss/clj-rss {:mvn/version "0.3.0"}
         ; io.github.stelcodes/vimhelp-minimal {:local/root "../clj-vimhelp"}
         io.github.stelcodes/vimhelp-minimal {:git/sha "a4ee25b90d53696aa9f5698721f4e4d763a5928e"}
+        expound/expound {:mvn/version "0.9.0"}
         ring/ring-core {:mvn/version "1.9.5"} ,
         ring/ring-devel {:mvn/version "1.9.5"} ,
         http-kit/http-kit {:mvn/version "2.5.3"},

--- a/src/nuzzle/config.clj
+++ b/src/nuzzle/config.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.edn :as edn]
    [clojure.spec.alpha :as s]
+   [expound.alpha :as expound]
    [nuzzle.log :as log]
    [nuzzle.schemas]
    [nuzzle.generator :as gen]))
@@ -9,11 +10,11 @@
 (defn validate-config [config]
   (if (s/valid? :nuzzle/user-config config)
     config
-    (let [errors (s/explain-str :nuzzle/user-config config)]
-      (log/error "Encountered error in nuzzle.edn config:")
-      (print errors)
-      (throw (ex-info "Invalid Nuzzle config"
-                      (s/explain-data :nuzzle/user-config config))))))
+    (do (expound/expound :nuzzle/user-config config {:theme :figwheel-theme})
+      (log/error "Encountered error in Nuzzle config:")
+      (throw (ex-info (str "Invalid Nuzzle config! "
+                           (re-find #"failed: .*" (s/explain-str :nuzzle/user-config config)))
+                      {})))))
 
 (defn read-config-path
   "Read the config from EDN file"

--- a/test-resources/edn/config-2-bad.edn
+++ b/test-resources/edn/config-2-bad.edn
@@ -1,0 +1,40 @@
+;; Missing the :nuzzle/base-url option - bad config
+
+{:nuzzle/build-drafts? true
+ :nuzzle/render-page nuzzle.config-test/render-page
+ :nuzzle/rss-channel {:title "Foo's blog"
+                      :description "Rants about foo and thoughts about bar"
+                      :link "https://foobar.com"}
+ :nuzzle/sitemap? true
+ :nuzzle/overlay-dir "public"
+ :nuzzle/publish-dir "/tmp/nuzzle-test-out"
+
+ [] {:nuzzle/title "Home"}
+
+ [:blog :nuzzle-rocks]
+ {:nuzzle/title "10 Reasons Why Nuzzle Rocks"
+  :nuzzle/content "test-resources/markdown/nuzzle-rocks.md"
+  :nuzzle/modified "2022-05-09"
+  :nuzzle/rss? true
+  :nuzzle/tags #{:nuzzle}}
+
+ [:blog :why-nuzzle]
+ {:nuzzle/title "Why I Made Nuzzle"
+  :nuzzle/content "test-resources/markdown/why-nuzzle.md"
+  :nuzzle/rss? true
+  :nuzzle/tags #{:nuzzle}}
+
+ [:blog :favorite-color]
+ {:nuzzle/title "What's My Favorite Color? It May Suprise You."
+  :nuzzle/content "test-resources/markdown/favorite-color.md"
+  :nuzzle/rss? true
+  :nuzzle/tags #{:colors}}
+
+ [:about]
+ {:nuzzle/title "About"
+  :nuzzle/content "test-resources/markdown/about.md"}
+
+ :meta
+ {:twitter "https://twitter/foobar"}}
+
+

--- a/test/nuzzle/config_test.clj
+++ b/test/nuzzle/config_test.clj
@@ -5,6 +5,8 @@
 
 (def config-path "test-resources/edn/config-1.edn")
 
+(def config-2-path "test-resources/edn/config-2-bad.edn")
+
 (def render-page (constantly [:h1 "test"]))
 
 (deftest read-config-path
@@ -35,3 +37,9 @@
                                :nuzzle/tags #{:nuzzle},
                                :nuzzle/title "Why I Made Nuzzle"}})))
 
+(deftest validate-config
+  (let [config-2 (conf/read-config-path config-2-path)
+        error-str (with-out-str (try (conf/validate-config config-2) (catch Throwable _ nil)))]
+    (spit "/tmp/poop.txt" (pr-str error-str))
+    (is (re-find #"Spec failed" error-str))
+    (is (re-find #"should contain key:.{6}:nuzzle/base-url" error-str))))


### PR DESCRIPTION
Previously the Nuzzle config validation would print very unfriendly
error messages. Now Nuzzle uses bhb/expound to print phenomenal
human-friendly error messages with color to the terminal when there is a
problem with the config.

Fixes #67