### PR TITLE
Create nuzzle.api.transform-diff function (#70)

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -21,5 +21,6 @@
         org.clojure/clojure {:mvn/version "1.11.1"},
         org.clojure/data.xml {:mvn/version "0.2.0-alpha6"}
         hiccup/hiccup {:mvn/version "2.0.0-alpha2"},
+        lambdaisland/deep-diff2 {:mvn/version "2.3.127"}
         stasis/stasis {:mvn/version "2.5.1"}},
  :paths ["src"]}

--- a/src/nuzzle/api.clj
+++ b/src/nuzzle/api.clj
@@ -1,5 +1,6 @@
 (ns nuzzle.api
-  (:require [nuzzle.config :as conf]
+  (:require [lambdaisland.deep-diff2 :as ddiff]
+            [nuzzle.config :as conf]
             [nuzzle.generator :as gen]
             [nuzzle.publish :as publish]
             [nuzzle.log :as log]
@@ -12,6 +13,16 @@
   (let [config (conf/load-default-config config-overrides)]
     (log/info "🔍🐈 Printing realized config for inspection")
     (-> config gen/realize-config)))
+
+(defn transform-diff
+  "Pretty prints the diff between the config in nuzzle.edn and the config after
+  Nuzzle's transformations."
+  [& {:as config-overrides}]
+  {:pre [(or (nil? config-overrides) (map? config-overrides))]}
+  (let [raw-config (conf/read-config-path "nuzzle.edn")
+        transformed-config (-> config-overrides conf/load-default-config gen/realize-config)]
+    (log/info "🔍🐈 Printing Nuzzle's config transformations diff")
+    (ddiff/pretty-print (ddiff/diff raw-config transformed-config))))
 
 (defn publish
   "Publishes the website to :nuzzle/publish-dir. The overlay directory is


### PR DESCRIPTION
Kaocha's colorized diffs are amazing and I wanted to include that with
Nuzzle. This patch adds a function to the nuzzle.api namespace that
pretty prints a diff between the config on disk and the config after
Nuzzle's transformations. This should help with debugging and
understanding how Nuzzle works.

Fixes #70