### PR TITLE
Replace "realize" terminology with "transform" (#71)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ Want to read some code already? Check out [this repo](https://github.com/stelcod
 Nuzzle's whole interface is just three functions in the `nuzzle.api` namespace:
 - `publish`: Exports the static site to disk.
 - `serve`: Starts a web server (http-kit) for a live preview of the website, building each page from scratch upon each request.
-- `realize`: Helper function for visualizing your config data after Nuzzle has transformed it.
+- `transform`: Returns your config after Nuzzle's transformations.
+- `transform-diff`: Pretty prints a colorized diff of your config before and after Nuzzle's transformations.
 
 All three functions have exactly the same interface:
 - They require no arguments.
@@ -164,7 +165,7 @@ Nuzzle's data pipeline can be visualized like so:
 ```
    ┌───────────┐           ┌───────────┐               ┌──────────────┐
    │           │           │           │               │              │
-   │  Config   │ ────┬───► │ Realized  │ ─────┬─────►  │  Hiccup that │
+   │  Config   │ ────┬───► │Transformed│ ─────┬─────►  │  Hiccup that │
    │   from    │     │     │ config    │      │        │ is converted │
    │ nuzzle.edn│     │     │           │      │        │ to HTML and  │
    │           │     │     │           │      │        │  published   │
@@ -173,7 +174,7 @@ Nuzzle's data pipeline can be visualized like so:
               transformations             function
 ```
 
-A key part of this process is the first arrow: Nuzzle's transformations. Nuzzle also calls this step **realizing** your config. A realized config looks very similar to the original, but with extra page entries and extra keys in the existing page entries.
+A key part of this process is the first arrow: Nuzzle's transformations. Nuzzle also calls this step **transforming** your config. A transformed config looks very similar to the original, but with extra page entries and extra keys in the existing page entries.
 
 ### Adding Keys to Page Entries
 Nuzzle adds these keys to every page map:
@@ -272,7 +273,7 @@ Here's an example of a page rendering function called `simple-render-page`:
 
 The `render-page` function uses the `:nuzzle/page-key` value to determine what Hiccup to return. This is how a single function can produce Hiccup for every page.
 
-Just because a page exists in your realized config doesn't mean you have to include it in your static site. If you don't want a page to be published, just return `nil`.
+Just because a page exists in your transformed config doesn't mean you have to include it in your static site. If you don't want a page to be published, just return `nil`.
 
 > In Nuzzle, all strings in the Hiccup are automatically escaped, so if you want to add a string of raw HTML, use the `nuzzle.hiccup/raw` wrapper function like so: `(raw "<h1>Title</h1>")`.
 
@@ -283,10 +284,10 @@ Instead of requiring your page rendering function to accept multiple arguments (
 
 In a word, `get-config` allows us to see the whole world while creating our Hiccup and let's us know if we are looking for something that doesn't exist. It has two forms:
 
-1. `(get-config)`: With no arguments, returns the whole realized config map.
+1. `(get-config)`: With no arguments, returns the whole transformed config map.
 2. `(get-config [:blog-posts])`: With one argument, returns value associated with provided config key or throws an exception.
 
-Since `get-config` returns maps from our *realized* config, all information about the site is at your fingertips. Every option and page entry from your config is always a function call away.
+Since `get-config` returns maps from our *transformed* config, all information about the site is at your fingertips. Every option and page entry from your config is always a function call away.
 
 Of course, any page entry map returned from `get-config` will also have a `:nuzzle/get-config` key attached to it. This naturally lends itself to a convention where most Hiccup-generating functions can accept a page entry map as its first or only argument while still being able to access any data in your Nuzzle config.
 

--- a/src/nuzzle/api.clj
+++ b/src/nuzzle/api.clj
@@ -6,13 +6,13 @@
             [nuzzle.log :as log]
             [nuzzle.ring :as ring]))
 
-(defn realize
+(defn transform
   "Allows the user to visualize the site data after Nuzzle's modifications."
   [& {:as config-overrides}]
   {:pre [(or (nil? config-overrides) (map? config-overrides))]}
   (let [config (conf/load-default-config config-overrides)]
-    (log/info "🔍🐈 Printing realized config for inspection")
-    (-> config gen/realize-config)))
+    (log/info "🔍🐈 Printing transformed config for inspection")
+    (-> config gen/transform-config)))
 
 (defn transform-diff
   "Pretty prints the diff between the config in nuzzle.edn and the config after
@@ -20,7 +20,7 @@
   [& {:as config-overrides}]
   {:pre [(or (nil? config-overrides) (map? config-overrides))]}
   (let [raw-config (conf/read-config-path "nuzzle.edn")
-        transformed-config (-> config-overrides conf/load-default-config gen/realize-config)]
+        transformed-config (-> config-overrides conf/load-default-config gen/transform-config)]
     (log/info "🔍🐈 Printing Nuzzle's config transformations diff")
     (ddiff/pretty-print (ddiff/diff raw-config transformed-config))))
 

--- a/src/nuzzle/config.clj
+++ b/src/nuzzle/config.clj
@@ -63,7 +63,7 @@
       read-config-path
       validate-config
       (transform-config config-overrides)
-      (gen/realize-config)))
+      (gen/transform-config)))
 
 (defn load-default-config [& {:as config-overrides}]
   (load-specified-config "nuzzle.edn" config-overrides))

--- a/src/nuzzle/generator.clj
+++ b/src/nuzzle/generator.clj
@@ -50,7 +50,7 @@
         {})))
 
 (defn gen-get-config
-  "Generate the helper function get-config from the realized config. This
+  "Generate the helper function get-config from the transformed config. This
   function takes a config key and returns the corresponding value with added
   key :nuzzle/get-config with value get-config function attached."
   [config]
@@ -64,8 +64,8 @@
        (throw (ex-info (str "get-config error: config key " ckey " not found")
                        {:key ckey}))))))
 
-(defn realize-config
-  "Creates fully realized config with or without drafts."
+(defn transform-config
+  "Creates fully transformed config with or without drafts."
   [{:nuzzle/keys [build-drafts?] :as config}]
   {:pre [(map? config)] :post [#(map? %)]}
   ;; Allow users to define their own overrides via deep-merge
@@ -79,7 +79,7 @@
                      acc
                      (assoc acc k v)))
                  {} config))))
-          (realize-pages [config]
+          (transform-pages [config]
             (reduce-kv
              (fn [acc ckey {:nuzzle/keys [content url] :as cval}]
                (if-not (map? cval)
@@ -95,7 +95,7 @@
       (handle-drafts $)
       (util/deep-merge $ (create-tag-index $))
       (util/deep-merge $ (create-group-index $))
-      (realize-pages $))))
+      (transform-pages $))))
 
 (defn generate-page-list
   "Creates a seq of maps which each represent a page in the website."

--- a/src/nuzzle/sitemap.clj
+++ b/src/nuzzle/sitemap.clj
@@ -9,8 +9,8 @@
 ;;http://www.sitemaps.org/protocol.html
 
 (defn create-sitemap
-  "Assumes realized site data is in map form and that drafts have already been
-  removed from rendered-site-index."
+  "Assumes config is transformed and drafts have already been removed from
+  rendered-site-index."
   [{:nuzzle/keys [base-url] :as config} rendered-site-index]
    (xml/emit-str
     {:tag :urlset

--- a/test/nuzzle/integration_test.clj
+++ b/test/nuzzle/integration_test.clj
@@ -73,7 +73,7 @@
 (comment (-> (read-ash-config) transform-ash-config create-ash-config-file
              (conf/load-specified-config) normalize-loaded-config))
 
-(deftest realize-config
+(deftest transform-config
   (is (= (-> (read-ash-config) transform-ash-config create-ash-config-file
              (conf/load-specified-config) normalize-loaded-config)
          {:nuzzle/publish-dir "out",


### PR DESCRIPTION
Previously the word "realize" was used to describe how Nuzzle changes
the incoming config and adds to it. Transform is a more familiar word
and more explicitly describes what's going on. Also trans pride! :3

Fixes #71 