### PR TITLE
Include page-key and get-config keys in transform-config function (#80)

### DIFF
--- a/test/nuzzle/integration_test.clj
+++ b/test/nuzzle/integration_test.clj
@@ -66,40 +66,54 @@
         (fn [cval]
           (if-not (:nuzzle/render-content cval)
             cval
-            (update cval :nuzzle/render-content #(%))))]
+            (update cval :nuzzle/render-content #(%))))
+        remove-get-config
+        (fn [cval]
+          (cond-> cval
+            (map? cval) (dissoc :nuzzle/get-config)))]
     (-> config
-        (update-vals trigger-render-content))))
+        (update-vals trigger-render-content)
+        (update-vals remove-get-config))))
 
 (comment (-> (read-ash-config) transform-ash-config create-ash-config-file
              (conf/load-specified-config) normalize-loaded-config))
 
 (deftest transform-config
-  (is (= (-> (read-ash-config) transform-ash-config create-ash-config-file
-             (conf/load-specified-config) normalize-loaded-config)
-         {:nuzzle/publish-dir "out",
-          :nuzzle/server-port 6899,
-          :nuzzle/base-url "https://ashketchum.com",
-          :nuzzle/render-page render-page
-          []
-          {:nuzzle/title "Home"
-           :nuzzle/content "test-resources/markdown/homepage-introduction.md",
-           :nuzzle/index #{[:about] [:blog-posts]},
-           :nuzzle/url "/",
-           :nuzzle/render-content '([:h1 {:id "placeholder"} "Placeholder"])},
-          [:blog-posts :catching-pikachu]
-          {:nuzzle/title "How I Caught Pikachu",
-           :nuzzle/content "test-resources/markdown/how-i-caught-pikachu.md",
-           :nuzzle/url "/blog-posts/catching-pikachu/",
-           :nuzzle/render-content '([:h1 {:id "placeholder"} "Placeholder"])},
-          [:about]
-          {:nuzzle/title "About Ash"
-           :nuzzle/content "test-resources/markdown/about-ash.md",
-           :nuzzle/url "/about/",
-           :nuzzle/render-content '([:h1 {:id "placeholder"} "Placeholder"])},
-          [:blog-posts]
-          {:nuzzle/index
-           #{[:blog-posts :catching-pikachu]},
-           :nuzzle/title "Blog Posts",
-           :nuzzle/url "/blog-posts/",
-           :nuzzle/content "test-resources/markdown/blog-header.md"
-           :nuzzle/render-content '([:p {} "Hi I'm Ash and this is my blog!"])}})))
+  (let [config (-> (read-ash-config) transform-ash-config create-ash-config-file
+                   (conf/load-specified-config))
+        normalized-config (normalize-loaded-config config)]
+    ;; Check that every page entry has a :nuzzle/get-config key
+    (is (every? (fn [[ckey cval]] (or (not (vector? ckey)) (contains? cval :nuzzle/get-config)))
+                config))
+    (is (= normalized-config
+           {:nuzzle/publish-dir "out",
+            :nuzzle/server-port 6899,
+            :nuzzle/base-url "https://ashketchum.com",
+            :nuzzle/render-page render-page
+            []
+            {:nuzzle/title "Home"
+             :nuzzle/content "test-resources/markdown/homepage-introduction.md",
+             :nuzzle/index #{[:about] [:blog-posts]},
+             :nuzzle/url "/",
+             :nuzzle/page-key []
+             :nuzzle/render-content '([:h1 {:id "placeholder"} "Placeholder"])},
+            [:blog-posts :catching-pikachu]
+            {:nuzzle/title "How I Caught Pikachu",
+             :nuzzle/content "test-resources/markdown/how-i-caught-pikachu.md",
+             :nuzzle/url "/blog-posts/catching-pikachu/",
+             :nuzzle/page-key [:blog-posts :catching-pikachu]
+             :nuzzle/render-content '([:h1 {:id "placeholder"} "Placeholder"])},
+            [:about]
+            {:nuzzle/title "About Ash"
+             :nuzzle/content "test-resources/markdown/about-ash.md",
+             :nuzzle/url "/about/",
+             :nuzzle/page-key [:about]
+             :nuzzle/render-content '([:h1 {:id "placeholder"} "Placeholder"])},
+            [:blog-posts]
+            {:nuzzle/index
+             #{[:blog-posts :catching-pikachu]},
+             :nuzzle/title "Blog Posts",
+             :nuzzle/url "/blog-posts/",
+             :nuzzle/page-key [:blog-posts]
+             :nuzzle/content "test-resources/markdown/blog-header.md"
+             :nuzzle/render-content '([:p {} "Hi I'm Ash and this is my blog!"])}}))))


### PR DESCRIPTION
Previously adding the :nuzzle/page-key and :nuzzle/get-config keys was
done after the nuzzle.generator/transform-config function (in the
nuzzle.generator/generate-page-list function). This means they were not
visible from the nuzzle.api.transform and nuzzle.api.transform-diff
functions.

Now the nuzzle.generate/transform-config function adds those keys to the
config map so the users to see all the transformations by the transform
API functions.

Fixes #80