### PR TITLE
Add author registry and page authors to config (#98)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ The Nuzzle config must be a map where each key is either a keyword or a vector o
 - `:nuzzle/build-drafts?` - A boolean that indicates whether pages marked as a draft should be included. Defaults to `false` (no drafts included).
 - `:nuzzle/publish-dir` - A path to a directory to publish the site into. Defaults to `"out"`.
 - `:nuzzle/overlay-dir` - A path to a directory that will be overlayed on top of the `:nuzzle/publish-dir` directory as the final stage of publishing. Defaults to `nil` (no overlay).
+- `:nuzzle/author-registry` - A map of keyword keys to map values which contain information about a website author. Used in conjunction with the `:nuzzle/author` page entry key.
 - `:nuzzle/server-port` - A port number for the development server to listen on. Defaults to `6899`.
 
 The following config options provide functionality above and beyond basic static site generation. They are totally optional.
@@ -131,6 +132,7 @@ The following config options provide functionality above and beyond basic static
 - `:nuzzle/tags`: A set of keywords where each keyword represents a tag name.
 - `:nuzzle/draft?`: A boolean indicating whether this page is a draft or not.
 - `:nuzzle/rss?`: A boolean indicating whether the page should be included in the optional RSS feed.
+- `:nuzzle/author`: A keyword representing the author of the page. The author must be registered in the `:nuzzle/author-registry` map.
 
 ## Understanding the Nuzzle Config
 

--- a/src/nuzzle/config.clj
+++ b/src/nuzzle/config.clj
@@ -4,13 +4,15 @@
    [clojure.spec.alpha :as s]
    [expound.alpha :as expound]
    [nuzzle.log :as log]
-   [nuzzle.schemas]
+   [nuzzle.schemas :as schemas]
    [nuzzle.generator :as gen]
    [nuzzle.util :as util]
    ;; Register spell-spec expound helpers after requiring expound.alpha
    [spell-spec.expound]))
 
 (defn validate-config [config]
+  ;; Redefine valid authors
+  (schemas/redefine-author-spec config)
   (if (s/valid? :nuzzle/user-config config)
     config
     (do (expound/expound :nuzzle/user-config config {:theme :figwheel-theme})

--- a/src/nuzzle/schemas.clj
+++ b/src/nuzzle/schemas.clj
@@ -7,21 +7,35 @@
 (def datetime-str? #(try (java.time.LocalDateTime/parse %) (catch Throwable _ nil)))
 (def zoned-datetime-str? #(try (java.time.ZonedDateTime/parse %) (catch Throwable _ nil)))
 
+(def http-url? #(re-find #"^https?://" %))
+
 ;; Page map keys
 (s/def :nuzzle/title string?)
 (s/def :nuzzle/rss? boolean?)
 (s/def :nuzzle/updated (s/or :date date-str? :datetime datetime-str? :zoned-datetime zoned-datetime-str?))
 (s/def :nuzzle/tags (s/coll-of keyword? :kind set?))
 (s/def :nuzzle/draft? boolean?)
+(s/def :nuzzle/author keyword?)
+;; Dynamically redefine :nuzzle/author based on config
+(defn redefine-author-spec [config]
+  (s/def :nuzzle/author (s/and keyword? (-> config :nuzzle/author-registry keys set))))
 
 ;; Syntax highlighter keys
 (s/def :nuzzle.syntax-highlighter/provider #{:chroma :pygments})
 (s/def :nuzzle.syntax-highlighter/style string?)
 (s/def :nuzzle.syntax-highlighter/line-numbers? boolean?)
 
+;; Author registry keys
+(s/def :nuzzle.author-registry/name string?)
+(s/def :nuzzle.author-registry/email string?)
+(s/def :nuzzle.author-registry/url http-url?)
+(s/def :nuzzle.author-registry/entry
+  (spell/keys :req-un [:nuzzle.author-registry/name]
+              :opt-un [:nuzzle.author-registry/email :nuzzle.author-registry/url]))
+
 ;; Config keys
 (s/def :nuzzle/render-page symbol?)
-(s/def :nuzzle/base-url #(re-find #"^https?://" %))
+(s/def :nuzzle/base-url http-url?)
 (s/def :nuzzle/syntax-highlighter
   (spell/keys :req-un [:nuzzle.syntax-highlighter/provider]
               :opt-un [:nuzzle.syntax-highlighter/style :nuzzle.syntax-highlighter/line-numbers?]))
@@ -33,6 +47,7 @@
 (s/def :nuzzle/publish-dir string?)
 (s/def :nuzzle/build-drafts? boolean?)
 (s/def :nuzzle/custom-elements (s/map-of keyword? symbol?))
+(s/def :nuzzle/author-registry (s/map-of keyword? :nuzzle.author-registry/entry))
 
 ;; Config Rules
 (s/def :nuzzle/page-key (s/coll-of keyword? :kind vector?))
@@ -46,7 +61,8 @@
   (s/and
    (spell/keys :req [:nuzzle/base-url :nuzzle/render-page]
                :opt [:nuzzle/syntax-highlighter :nuzzle/rss-channel :nuzzle/build-drafts?
-                     :nuzzle/sitemap? :nuzzle/custom-elements :nuzzle/publish-dir :nuzzle/overlay-dir])
+                     :nuzzle/sitemap? :nuzzle/custom-elements :nuzzle/publish-dir :nuzzle/overlay-dir
+                     :nuzzle/author-registry])
    (s/every :nuzzle/config-entry)))
 
 (comment

--- a/test-resources/edn/config-1.edn
+++ b/test-resources/edn/config-1.edn
@@ -4,6 +4,9 @@
  :nuzzle/rss-channel {:title "Foo's blog"
                       :description "Rants about foo and thoughts about bar"
                       :link "https://foobar.com"}
+ :nuzzle/author-registry {:shelly {:name "Shelly Johnson" :email "shellyj@mail.com"}
+                          :donna {:name "Donna Hayward" :email "donnah@mail.com" :url "https://donnahayward.com"}
+                          :josie {:name "Josie Packard"}}
  :nuzzle/sitemap? true
  :nuzzle/overlay-dir "public"
  :nuzzle/publish-dir "/tmp/nuzzle-test-out"
@@ -14,18 +17,21 @@
  {:nuzzle/title "10 Reasons Why Nuzzle Rocks"
   :nuzzle/content "test-resources/markdown/nuzzle-rocks.md"
   :nuzzle/updated "2022-05-09T12:00Z"
+  :nuzzle/author :shelly
   :nuzzle/rss? true
   :nuzzle/tags #{:nuzzle}}
 
  [:blog :why-nuzzle]
  {:nuzzle/title "Why I Made Nuzzle"
   :nuzzle/content "test-resources/markdown/why-nuzzle.md"
+  :nuzzle/author :donna
   :nuzzle/rss? true
   :nuzzle/tags #{:nuzzle}}
 
  [:blog :favorite-color]
  {:nuzzle/title "What's My Favorite Color? It May Suprise You."
   :nuzzle/content "test-resources/markdown/favorite-color.md"
+  :nuzzle/author :josie
   :nuzzle/rss? true
   :nuzzle/tags #{:colors}}
 

--- a/test/nuzzle/schemas_test.clj
+++ b/test/nuzzle/schemas_test.clj
@@ -1,14 +1,14 @@
-(ns nuzzle.schemas-test)
+(ns nuzzle.schemas-test
+  (:require
+   [clojure.spec.alpha :as s]
+   [clojure.test :refer [deftest is]]
+   [nuzzle.schemas]))
 
-;; (deftest syntax-highlighter
-;;   (is (m/validate schemas/syntax-highlighter
-;;                   {:provider :chroma
-;;                    :style "emacs"})))
-;;
-;; (deftest local-date
-;;   (is (m/validate schemas/local-date
-;;                   (m/decode schemas/local-date "2022-05-04"
-;;                             (mt/transformer {:name :local-date}))))
-;;   (is (not (m/validate schemas/local-date
-;;                        (m/decode schemas/local-date "2022-05-04jhfklsdjf"
-;;                                  (mt/transformer {:name :local-date}))))))
+(deftest author-registry
+  (is (s/valid? :nuzzle/author-registry {:stel {:name "Stelly Luna"}}))
+  (is (s/valid? :nuzzle/author-registry {:stel {:name "Stelly Luna" :email "stel@email.com"}}))
+  (is (s/valid? :nuzzle/author-registry {:stel {:name "Stelly Luna" :email "stel@email.com" :url "https://stel.com"}}))
+  (is (not (s/valid? :nuzzle/author-registry {:stel {:name 77777777777}})))
+  (is (not (s/valid? :nuzzle/author-registry {:stel {:name "Stelly Luna" :email "stel@email.com" :url "stel.com"}})))
+  (is (not (s/valid? :nuzzle/author-registry {:stel {:name "Stelly Luna" :emailz "stel@email.com"}}))))
+  (is (not (s/valid? :nuzzle/author-registry {:stel {:email "stel@email.com"}})))


### PR DESCRIPTION
This change introduces a new feature where pages can be tagged with a
`:nuzzle/author` key with a keyword value like `:laura` that represents
an author. All author keywords must be present in the top-level
`:nuzzle/author-registry` map which contains information about these
authors.

This feature is part of the migration to the Atom feed integration. Atom
defines authors for both the feed and individual pages. The author
registry will be used for both of these purposes.

Fixes #98