### PR TITLE
Fix Atom XML by removing invalid subtitle tag (#113)

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,6 @@ The following config options provide functionality above and beyond basic static
 - `:nuzzle/draft?`: A boolean indicating whether this page is a draft or not.
 - `:nuzzle/feed?`: A boolean indicating whether the page should be included in the optional Atom feed.
 - `:nuzzle/tags`: A set of keywords where each keyword represents a tag name.
-- `:nuzzle/subtitle`: A string subtitle for the web page.
 - `:nuzzle/updated`: A timestamp string representing when the page was last updated.
 - `:nuzzle/summary`: A string summary of the page content.
 - `:nuzzle/author`: A keyword representing the author of the page. The author must be registered in the `:nuzzle/author-registry` map.

--- a/src/nuzzle/feed.clj
+++ b/src/nuzzle/feed.clj
@@ -53,7 +53,7 @@
               :content subtitle})]
           (for [[rel-url _] rendered-site-index
                 :let [page-key (util/url->page-key rel-url)
-                      {:nuzzle/keys [updated summary author title subtitle content render-content feed?]} (get config page-key)
+                      {:nuzzle/keys [updated summary author title content render-content feed?]} (get config page-key)
                       content-result (when (fn? render-content) (render-content))
                       abs-url (str base-url rel-url)]
                 :when feed?]
@@ -62,9 +62,6 @@
                         :content title}
                        {:tag ::atom/id
                         :content abs-url}
-                       (when subtitle
-                         {:tag ::atom/subtitle
-                          :content subtitle})
                        (when content-result
                          {:tag ::atom/content
                           :attrs {:type "html"}


### PR DESCRIPTION
I thought there was a subtitle tag for atom entries but there is not.

Fixes #113