### PR TITLE
Move gen/transform-config to nuzzle.config ns (#118)

### DIFF
--- a/src/nuzzle/api.clj
+++ b/src/nuzzle/api.clj
@@ -1,7 +1,6 @@
 (ns nuzzle.api
   (:require [lambdaisland.deep-diff2 :as ddiff]
             [nuzzle.config :as conf]
-            [nuzzle.generator :as gen]
             [nuzzle.publish :as publish]
             [nuzzle.log :as log]
             [nuzzle.ring :as ring]))
@@ -10,17 +9,16 @@
   "Allows the user to visualize the site data after Nuzzle's modifications."
   [& {:as config-overrides}]
   {:pre [(or (nil? config-overrides) (map? config-overrides))]}
-  (let [config (conf/load-default-config config-overrides)]
-    (log/info "🔍🐈 Printing transformed config for inspection")
-    (-> config gen/transform-config)))
+  (log/info "🔍🐈 Returning transformed config")
+  (conf/load-default-config config-overrides))
 
 (defn transform-diff
   "Pretty prints the diff between the config in nuzzle.edn and the config after
   Nuzzle's transformations."
   [& {:as config-overrides}]
   {:pre [(or (nil? config-overrides) (map? config-overrides))]}
-  (let [raw-config (conf/read-config-path "nuzzle.edn")
-        transformed-config (-> config-overrides conf/load-default-config gen/transform-config)]
+  (let [raw-config (conf/read-config-from-path "nuzzle.edn")
+        transformed-config (conf/load-default-config config-overrides)]
     (log/info "🔍🐈 Printing Nuzzle's config transformations diff")
     (ddiff/pretty-print (ddiff/diff raw-config transformed-config))))
 

--- a/src/nuzzle/schemas.clj
+++ b/src/nuzzle/schemas.clj
@@ -9,6 +9,8 @@
 
 (def http-url? #(re-find #"^https?://" %))
 
+(def resolvable-symbol? #(try (requiring-resolve %) (catch Throwable _ nil)))
+
 ;; Page map keys
 (s/def :nuzzle/title string?)
 (s/def :nuzzle/feed? boolean?)
@@ -44,7 +46,7 @@
   (s/def :nuzzle.atom-feed/author (s/and keyword? (-> config :nuzzle/author-registry keys set))))
 
 ;; Config keys
-(s/def :nuzzle/render-page symbol?)
+(s/def :nuzzle/render-page (s/and symbol? resolvable-symbol?))
 (s/def :nuzzle/base-url http-url?)
 (s/def :nuzzle/syntax-highlighter
   (spell/keys :req-un [:nuzzle.syntax-highlighter/provider]

--- a/test/nuzzle/config_test.clj
+++ b/test/nuzzle/config_test.clj
@@ -9,8 +9,8 @@
 
 (def render-page (constantly [:h1 "test"]))
 
-(deftest read-config-path
-  (is (= (conf/read-config-path config-path)
+(deftest read-config-from-path
+  (is (= (conf/read-config-from-path config-path)
          {:nuzzle/publish-dir "/tmp/nuzzle-test-out",
           :nuzzle/base-url "https://foobar.com"
           :nuzzle/sitemap? true
@@ -51,8 +51,10 @@
 
 (deftest validate-config
   (testing "bad config fails with expound output"
-    (let [config-2 (conf/read-config-path config-2-path)
-          error-str (with-out-str (try (conf/validate-config config-2) (catch Throwable _ nil)))]
+    (let [error-str (with-out-str (try (-> config-2-path
+                                           conf/read-config-from-path
+                                           conf/validate-config)
+                                    (catch Throwable _ nil)))]
       (is (re-find #"Spec failed" error-str))
       (is (re-find #"should contain key:.{6}:nuzzle/base-url" error-str))))
   (testing "author registry author validation works"

--- a/test/nuzzle/content_test.clj
+++ b/test/nuzzle/content_test.clj
@@ -6,7 +6,7 @@
 
 (def config-path "test-resources/edn/config-1.edn")
 
-(defn config [] (conf/load-specified-config config-path {}))
+(defn config [] (conf/load-config-from-path config-path))
 
 (deftest generate-highlight-command
   (testing "generating chroma command"

--- a/test/nuzzle/feed_test.clj
+++ b/test/nuzzle/feed_test.clj
@@ -6,7 +6,7 @@
    [nuzzle.feed :as feed]
    [nuzzle.generator :as gen]))
 
-(defn config [] (conf/load-specified-config "test-resources/edn/config-1.edn"))
+(defn config [] (conf/load-config-from-path "test-resources/edn/config-1.edn"))
 
 (deftest create-atom-feed
   (let [config (config)

--- a/test/nuzzle/generator_test.clj
+++ b/test/nuzzle/generator_test.clj
@@ -5,7 +5,7 @@
 
 (def config-path "test-resources/edn/config-1.edn")
 
-(defn config [] (conf/read-config-path config-path))
+(defn config [] (conf/read-config-from-path config-path))
 
 (deftest create-tag-index
   (is (= {[:tags :bar]
@@ -47,7 +47,7 @@
          (gen/create-group-index (config)))))
 
 (deftest gen-get-config
-  (let [config (conf/load-specified-config config-path)
+  (let [config (conf/load-config-from-path config-path)
         get-config (gen/gen-get-config config)]
     (is (= "https://foobar.com" (get-config :nuzzle/base-url)))
     (is (= "https://twitter/foobar" (get-config :meta :twitter)))

--- a/test/nuzzle/integration_test.clj
+++ b/test/nuzzle/integration_test.clj
@@ -76,11 +76,11 @@
         (update-vals remove-get-config))))
 
 (comment (-> (read-ash-config) transform-ash-config create-ash-config-file
-             (conf/load-specified-config) normalize-loaded-config))
+             (conf/load-config-from-path) normalize-loaded-config))
 
 (deftest transform-config
   (let [config (-> (read-ash-config) transform-ash-config create-ash-config-file
-                   (conf/load-specified-config))
+                   (conf/load-config-from-path))
         normalized-config (normalize-loaded-config config)]
     ;; Check that every page entry has a :nuzzle/get-config key
     (is (every? (fn [[ckey cval]] (or (not (vector? ckey)) (contains? cval :nuzzle/get-config)))

--- a/test/nuzzle/publish_test.clj
+++ b/test/nuzzle/publish_test.clj
@@ -11,7 +11,7 @@
 
 (def config-path "test-resources/edn/config-1.edn")
 
-(defn config [] (conf/load-specified-config config-path {}))
+(defn config [] (conf/load-config-from-path config-path))
 
 (deftest publish-feed
   (let [temp-dir (fs/create-temp-dir)

--- a/test/nuzzle/sitemap_test.clj
+++ b/test/nuzzle/sitemap_test.clj
@@ -9,7 +9,7 @@
 
 (def config-path "test-resources/edn/config-1.edn")
 
-(defn config [] (conf/load-specified-config config-path {}))
+(defn config [] (conf/load-config-from-path config-path))
 
 (deftest create-sitemap
   (is (= (-> "test-resources/xml/empty-sitemap.xml" slurp str/trim)


### PR DESCRIPTION
Moved nuzzle.generator/transform-config to the config ns as part of the
effort to break down and remove the nuzzle.generator namespace.

I also cleaned up the nuzzle.config a bit too, renaming the functions to
be more uniform.