### PR TITLE
Add internal toggle for `render-content` function laziness (#115)

### DIFF
--- a/src/nuzzle/api.clj
+++ b/src/nuzzle/api.clj
@@ -10,7 +10,7 @@
   [& {:as config-overrides}]
   {:pre [(or (nil? config-overrides) (map? config-overrides))]}
   (log/info "🔍🐈 Returning transformed config")
-  (conf/load-default-config config-overrides))
+  (conf/load-default-config :config-overrides config-overrides))
 
 (defn transform-diff
   "Pretty prints the diff between the config in nuzzle.edn and the config after
@@ -18,7 +18,7 @@
   [& {:as config-overrides}]
   {:pre [(or (nil? config-overrides) (map? config-overrides))]}
   (let [raw-config (conf/read-config-from-path "nuzzle.edn")
-        transformed-config (conf/load-default-config config-overrides)]
+        transformed-config (conf/load-default-config :config-overrides config-overrides)]
     (log/info "🔍🐈 Printing Nuzzle's config transformations diff")
     (ddiff/pretty-print (ddiff/diff raw-config transformed-config))))
 
@@ -28,12 +28,11 @@
   published."
   [& {:as config-overrides}]
   {:pre [(or (nil? config-overrides) (map? config-overrides))]}
-  (-> config-overrides
-      (conf/load-default-config)
+  (-> (conf/load-default-config :config-overrides config-overrides)
       (publish/publish-site)))
 
 (defn serve
   "Starts a server using http-kit for development."
   [& {:as config-overrides}]
   {:pre [(or (nil? config-overrides) (map? config-overrides))]}
-  (server/start-server config-overrides))
+  (server/start-server :config-overrides config-overrides))

--- a/src/nuzzle/config.clj
+++ b/src/nuzzle/config.clj
@@ -186,15 +186,15 @@
 
 (defn load-config-from-path
   "Read a config EDN file and validate it."
-  [config-path & {:as config-overrides}]
+  [config-path & {:keys [config-overrides] :as opts}]
   (-> config-path
       read-config-from-path
       (util/deep-merge config-overrides)
       validate-config
-      transform-config))
+      (transform-config opts)))
 
-(defn load-default-config [& {:as config-overrides}]
-  (load-config-from-path "nuzzle.edn" config-overrides))
+(defn load-default-config [& {:as opts}]
+  (load-config-from-path "nuzzle.edn" opts))
 
 (comment (load-config-from-path "test-resources/edn/config-1.edn" {}))
 

--- a/src/nuzzle/config.clj
+++ b/src/nuzzle/config.clj
@@ -127,7 +127,7 @@
 
 (defn transform-config
   "Creates fully transformed config with or without drafts."
-  [{:nuzzle/keys [build-drafts?] :as config}]
+  [{:nuzzle/keys [build-drafts?] :as config} & {:as opts}]
   {:pre [(map? config)] :post [#(map? %)]}
   ;; Allow users to define their own overrides via deep-merge
   (letfn [(apply-defaults [config]
@@ -164,7 +164,7 @@
                         (vector? ckey) (assoc :nuzzle/url (util/page-key->url ckey)
                                               :nuzzle/page-key ckey)
                         (or (vector? ckey) content) (assoc :nuzzle/render-content
-                                                           (content/create-render-content-fn ckey config)))))
+                                                           (content/create-render-content-fn ckey config opts)))))
              {} config))
           (add-get-config-to-pages [config]
             (let [get-config (create-get-config config)]

--- a/src/nuzzle/config.clj
+++ b/src/nuzzle/config.clj
@@ -1,4 +1,5 @@
 (ns nuzzle.config
+  ;; (:use clojure.stacktrace)
   (:require
    [clojure.edn :as edn]
    [clojure.spec.alpha :as s]
@@ -187,6 +188,7 @@
 (defn load-config-from-path
   "Read a config EDN file and validate it."
   [config-path & {:keys [config-overrides] :as opts}]
+  ;; (print-stack-trace (ex-info "LOADING CONFIG" {:path config-path}) 12)
   (-> config-path
       read-config-from-path
       (util/deep-merge config-overrides)

--- a/src/nuzzle/config.clj
+++ b/src/nuzzle/config.clj
@@ -202,13 +202,13 @@
   "Creates a map where the keys are relative URLs and the values are a string
   of HTML or a function that produces a string of HTML. This datastructure is
   defined by stasis."
-  [{:nuzzle/keys [render-page] :as config} & {:keys [lazy?]}]
+  [{:nuzzle/keys [render-page] :as config} & {:keys [lazy-render?]}]
   {:pre [(fn? render-page)] :post [(map? %)]}
   (reduce-kv
    (fn [acc ckey cval]
      (if-let [render-result (and (vector? ckey) (render-page cval))]
        (assoc acc (:nuzzle/url cval)
-              (if lazy?
+              (if lazy-render?
                 ;; Turn the page's hiccup into HTML on the fly
                 (fn [_]
                   (log/log-rendering-page cval)

--- a/src/nuzzle/content.clj
+++ b/src/nuzzle/content.clj
@@ -1,4 +1,5 @@
 (ns nuzzle.content
+  ;; (:use clojure.stacktrace)
   (:require
    [babashka.fs :as fs]
    [clojure.string :as str]
@@ -96,6 +97,7 @@
     [:pre [:code.code-block code]]))
 
 (defn process-markdown-file [file config]
+  ;; (print-stack-trace (ex-info "PROCESSING MARKDOWN FILE" {:file file}) 12)
   (let [code-block-with-config #(code-block->hiccup % config)
         lower-fns {:markdown/fenced-code-block code-block-with-config
                    :markdown/indented-code-block code-block-with-config}

--- a/src/nuzzle/server.clj
+++ b/src/nuzzle/server.clj
@@ -38,13 +38,14 @@
   "Loads config and adds it to the request map under they key :config"
   [app config-overrides]
   (fn [request]
-    (let [config (conf/load-default-config config-overrides)]
+    (let [config (conf/load-default-config :config-overrides config-overrides)]
       (-> request
           (assoc :config config)
           (app)))))
 
-(defn start-server [config-overrides]
-  (let [{:nuzzle/keys [server-port]} (conf/load-default-config config-overrides)]
+(defn start-server [& {:keys [config-overrides]}]
+  (let [{:nuzzle/keys [server-port]}
+        (conf/load-default-config :config-overrides config-overrides :lazy-render? true)]
     (log/log-start-server server-port)
     (-> handle-page-request
         (wrap-overlay-dir)

--- a/src/nuzzle/server.clj
+++ b/src/nuzzle/server.clj
@@ -30,7 +30,7 @@
   config to be passed down from wrap-overlay-dir, avoiding an unecessary config
   load"
   [{:keys [config] :as request}]
-  (let [get-pages #(conf/create-site-index config :lazy? true)
+  (let [get-pages #(conf/create-site-index config :lazy-render? true)
         app (stasis/serve-pages get-pages)]
     (app request)))
 


### PR DESCRIPTION
Now the render-content functions can either be lazy (don't process content file until called) or eager (process the content file once up front and return a static value. The former is better for the development server and the latter is better for publishing.