### PR TITLE
Add :nuzzle/ignore-pages config option (#130)

### DIFF
--- a/src/nuzzle/schemas.clj
+++ b/src/nuzzle/schemas.clj
@@ -61,6 +61,7 @@
 (s/def :nuzzle/build-drafts? boolean?)
 (s/def :nuzzle/custom-elements (s/map-of keyword? symbol?))
 (s/def :nuzzle/author-registry (s/map-of keyword? :nuzzle.author-registry/entry))
+(s/def :nuzzle/ignore-pages (s/coll-of :nuzzle/page-key :kind set?))
 
 ;; Config Rules
 (s/def :nuzzle/page-key (s/coll-of keyword? :kind vector?))
@@ -75,7 +76,7 @@
    (spell/keys :req [:nuzzle/base-url :nuzzle/render-page]
                :opt [:nuzzle/syntax-highlighter :nuzzle/atom-feed :nuzzle/build-drafts?
                      :nuzzle/sitemap? :nuzzle/custom-elements :nuzzle/publish-dir :nuzzle/overlay-dir
-                     :nuzzle/author-registry])
+                     :nuzzle/author-registry :nuzzle/ignore-pages])
    (s/every :nuzzle/config-entry)))
 
 (comment


### PR DESCRIPTION
This change adds the :nuzzle/ignore-pages option which is a set of page
keys that must not be in the config after the transformation process.
This allows the user to ignore pages that Nuzzle automatically
generates.

Previously this was done by returning nil from the user's render-page
function. Now this method is abandoned. Returning nil will result in
errors when trying to export and blank pages when using the development
server.

Fixes #130