### PR TITLE
Remove string URL in page map, replace with vector URL (#135)

### DIFF
--- a/src/nuzzle/config.clj
+++ b/src/nuzzle/config.clj
@@ -49,7 +49,7 @@
   /tags/ subdirectory"
   [config]
   (->> config
-       ;; Create a map shaped like {tag-kw #{page-keys-with-tag}}
+       ;; Create a map shaped like {tag-kw #{url url ...}}
        (reduce-kv
         ;; For every key value pair in config
         (fn [acc ckey {:nuzzle/keys [tags]}]
@@ -73,7 +73,7 @@
   pages have parent pages going up to the root page"
   [config]
   (->> config
-       ;; Create a map shaped like {page-key #{child-page-keys}}
+       ;; Create a map shaped like {url #{child-url child-url ...}}
        (reduce-kv
         ;; For every key value pair in config
         (fn [acc ckey _]
@@ -171,8 +171,7 @@
              (fn [acc ckey {:nuzzle/keys [content] :as cval}]
                (assoc acc ckey
                       (cond-> cval
-                        (vector? ckey) (assoc :nuzzle/url (util/page-key->url ckey)
-                                              :nuzzle/page-key ckey)
+                        (vector? ckey) (assoc :nuzzle/url ckey)
                         (or (vector? ckey) content) (assoc :nuzzle/render-content
                                                            (content/create-render-content-fn ckey config opts)))))
              {} config))
@@ -217,9 +216,9 @@
   [{:nuzzle/keys [render-page] :as config} & {:keys [lazy-render?]}]
   {:pre [(fn? render-page)] :post [(map? %)]}
   (reduce-kv
-   (fn [acc ckey cval]
+   (fn [acc ckey {:nuzzle/keys [url] :as cval}]
      (if (vector? ckey)
-       (assoc acc (:nuzzle/url cval)
+       (assoc acc (util/stringify-url url)
               (if lazy-render?
                 ;; Turn the page's hiccup into HTML on the fly
                 (fn [_]

--- a/src/nuzzle/content.clj
+++ b/src/nuzzle/content.clj
@@ -114,9 +114,9 @@
 (defn create-render-content-fn
   "Create a function that turns the :nuzzle/content file into the correct form for the
   hiccup compiler: vector, list, or raw string"
-  [page-key config & {:keys [lazy-render?] :as _opts}]
-  {:pre [(or (vector? page-key) (keyword? page-key))]}
-  (if-let [content (get-in config [page-key :nuzzle/content])]
+  [url config & {:keys [lazy-render?] :as _opts}]
+  {:pre [(or (vector? url) (keyword? url))]}
+  (if-let [content (get-in config [url :nuzzle/content])]
     (let [content-file (fs/file content)
           content-ext (fs/extension content-file)]
       (if (fs/exists? content-file)
@@ -128,12 +128,12 @@
                                          #(process-html-file content-file config)
                                          (constantly (process-html-file content-file config)))
          :else (throw (ex-info (str "Content file " (fs/canonicalize content-file)
-                                    " for page " page-key " has unrecognized extension "
+                                    " for page " url " has unrecognized extension "
                                     content-ext ". Must be one of: md, markdown, html, htm")
-                               {:nuzzle/page-key page-key :nuzzle/content content})))
+                               {:nuzzle/url url :nuzzle/content content})))
         ;; If markdown-file is defined but it can't be found, throw an Exception
         (throw (ex-info (str "Content file " (fs/canonicalize content-file)
-                             " for page " page-key " not found")
-                        {:nuzzle/page-key page-key :nuzzle/content content}))))
+                             " for page " url " not found")
+                        {:nuzzle/url url :nuzzle/content content}))))
     ;; If :nuzzle/content is not defined, just make a function that returns nil
     (constantly nil)))

--- a/src/nuzzle/publish.clj
+++ b/src/nuzzle/publish.clj
@@ -24,10 +24,10 @@
    (xml/emit-str
     {:tag ::sm/urlset
      :content
-     (for [[rel-url _hiccup] rendered-site-index
-           :let [page-key (util/url->page-key rel-url)
-                 {:nuzzle/keys [content updated]} (get config page-key)
-                 abs-url (str base-url rel-url)]]
+     (for [[url-str _hiccup] rendered-site-index
+           :let [url-vec (util/vectorize-url url-str)
+                 {:nuzzle/keys [content updated]} (get config url-vec)
+                 abs-url (str base-url url-str)]]
        {:tag ::sm/url
         :content
         [{:tag ::sm/loc
@@ -78,11 +78,11 @@
            (when-let [subtitle (:subtitle atom-feed)]
              {:tag ::atom/subtitle
               :content subtitle})]
-          (for [[rel-url _] rendered-site-index
-                :let [page-key (util/url->page-key rel-url)
-                      {:nuzzle/keys [updated summary author title content render-content feed?]} (get config page-key)
+          (for [[url-str _] rendered-site-index
+                :let [url-vec (util/vectorize-url url-str)
+                      {:nuzzle/keys [updated summary author title content render-content feed?]} (get config url-vec)
                       content-result (when (fn? render-content) (render-content))
-                      abs-url (str base-url rel-url)]
+                      abs-url (str base-url url-str)]
                 :when feed?]
             {:tag ::atom/entry
              :content [{:tag ::atom/title

--- a/src/nuzzle/util.clj
+++ b/src/nuzzle/util.clj
@@ -13,13 +13,13 @@
     (apply merge-with deep-merge a maps)
     (apply merge-with deep-merge maps)))
 
-(defn page-key->url
-  [page-key]
-  {:pre [(vector? page-key)]}
-  (if (= [] page-key) "/"
-    (str "/" (string/join "/" (map name page-key)) "/")))
+(defn stringify-url
+  [url]
+  {:pre [(vector? url)]}
+  (if (= [] url) "/"
+    (str "/" (string/join "/" (map name url)) "/")))
 
-(defn url->page-key
+(defn vectorize-url
   [url]
   {:pre [(string? url)]}
   (->> (string/split url #"/")

--- a/test/nuzzle/config_test.clj
+++ b/test/nuzzle/config_test.clj
@@ -113,7 +113,7 @@
         get-config (conf/create-get-config config)]
     (is (= "https://foobar.com" (get-config :nuzzle/base-url)))
     (is (= "https://twitter/foobar" (get-config :meta :twitter)))
-    (is (= "/about/" (get-config [:about] :nuzzle/url)))
+    (is (= [:about] (get-config [:about] :nuzzle/url)))
     (is (= #{[:blog :favorite-color] [:blog :nuzzle-rocks] [:blog :why-nuzzle]}
            (get-config [:blog] :nuzzle/index)))
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"get-config error: config key sequence \[:bad-key\] cannot be resolved"

--- a/test/nuzzle/integration_test.clj
+++ b/test/nuzzle/integration_test.clj
@@ -94,26 +94,22 @@
             {:nuzzle/title "Home"
              :nuzzle/content "test-resources/markdown/homepage-introduction.md",
              :nuzzle/index #{[:about] [:blog-posts]},
-             :nuzzle/url "/",
-             :nuzzle/page-key []
+             :nuzzle/url []
              :nuzzle/render-content '([:h1 {:id "placeholder"} "Placeholder"])},
             [:blog-posts :catching-pikachu]
             {:nuzzle/title "How I Caught Pikachu",
              :nuzzle/content "test-resources/markdown/how-i-caught-pikachu.md",
-             :nuzzle/url "/blog-posts/catching-pikachu/",
-             :nuzzle/page-key [:blog-posts :catching-pikachu]
+             :nuzzle/url [:blog-posts :catching-pikachu]
              :nuzzle/render-content '([:h1 {:id "placeholder"} "Placeholder"])},
             [:about]
             {:nuzzle/title "About Ash"
              :nuzzle/content "test-resources/markdown/about-ash.md",
-             :nuzzle/url "/about/",
-             :nuzzle/page-key [:about]
+             :nuzzle/url [:about]
              :nuzzle/render-content '([:h1 {:id "placeholder"} "Placeholder"])},
             [:blog-posts]
             {:nuzzle/index
              #{[:blog-posts :catching-pikachu]},
              :nuzzle/title "Blog Posts",
-             :nuzzle/url "/blog-posts/",
-             :nuzzle/page-key [:blog-posts]
+             :nuzzle/url [:blog-posts]
              :nuzzle/content "test-resources/markdown/blog-header.md"
              :nuzzle/render-content '([:p {} "Hi I'm Ash and this is my blog!"])}}))))

--- a/test/nuzzle/util_test.clj
+++ b/test/nuzzle/util_test.clj
@@ -3,13 +3,13 @@
    [clojure.test :refer [deftest is]]
    [nuzzle.util :as util]))
 
-(deftest url->page-key
+(deftest vectorize-url
   (is (= (list [:about] [] [:blog-posts :foo])
-         (map util/url->page-key ["/about/" "/" "/blog-posts/foo/"]))))
+         (map util/vectorize-url ["/about/" "/" "/blog-posts/foo/"]))))
 
-(deftest page-key->url
-  (is (= "/blog-posts/my-hobbies/" (util/page-key->url [:blog-posts :my-hobbies])))
-  (is (= "/about/" (util/page-key->url [:about]))))
+(deftest stringify-url
+  (is (= "/blog-posts/my-hobbies/" (util/stringify-url [:blog-posts :my-hobbies])))
+  (is (= "/about/" (util/stringify-url [:about]))))
 
 (deftest time-str->?inst
   (is (inst? (util/time-str->?inst "2022-05-04")))


### PR DESCRIPTION
This patch merges together :nuzzle/page-key and :nuzzle/url into just :nuzzle/url which is the vector representation of the page URL. The string version will now only be available by calling the nuzzle.util/stringify-url function on the vector URL.

This simplifies the page data by making the vector format the canonical representation of a URL in Nuzzle. Eventually I want to customize the Hiccup creation so a vector URL can be used as an link tag's :href value.

Fixes #135