### PR TITLE
Require literal config map, remove nuzzle.edn (#133)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,7 @@ Nuzzle's whole interface is just four functions in the `nuzzle.api` namespace:
 - `transform`: Returns your config after Nuzzle's transformations.
 - `transform-diff`: Pretty prints a colorized diff of your config before and after Nuzzle's transformations.
 
-All three functions have exactly the same interface:
-- They require no arguments.
-- They accept keyword arguments which you can use to override the values of your configuration file.
+All these functions accept a single argument: the config map.
 
 ```
 clj -Sdeps '{:deps {codes.stel/nuzzle {:mvn/version "0.5.320"}}}'
@@ -59,22 +57,23 @@ clj -Sdeps '{:deps {codes.stel/nuzzle {:mvn/version "0.5.320"}}}'
 ```clojure
 (require '[nuzzle.api :as nuzz])
 
-;; You will need a config file at nuzzle.edn before running these functions successfully
+;; Create a config map
+(def config {...})
 
 ;; Start development server
-;; You can stop the development server by saving the returned function
-(def stop (nuzz/serve :nuzzle/build-drafts? true))
-;; Call (stop) later
+;; Pass the config as a var to get awesome hot-reloading capabilities!
+;; The returned value is a function that stops the server.
+(nuzz/serve #'config)
 
-;; Publish the static site
-(nuzz/publish)
+;; Publish the static site, returns nil
+(nuzz/publish config)
 
-;; Visualize Nuzzle's data pipeline
-(nuzz/transform-diff)
+;; Prints a diff of all changes Nuzzle made to the config before using it, returns nil
+(nuzz/transform-diff config)
 ```
 
-## Configuration File
-Nuzzle expects to find an EDN map in the file `nuzzle.edn` in your current working directory. This file is where you will store your Nuzzle config. The config is validated by `clojure.spec`. You can find the [config spec here](https://github.com/stelcodes/nuzzle/blob/main/src/nuzzle/schemas.clj).
+## Configuration Map
+Nuzzle builds your static site from a map of configuration values. The config is validated by `clojure.spec`. You can find the [config spec here](https://github.com/stelcodes/nuzzle/blob/main/src/nuzzle/schemas.clj).
 
 If you're from Pallet town, your `nuzzle.edn` config might look like this:
 ```clojure

--- a/src/nuzzle/api.clj
+++ b/src/nuzzle/api.clj
@@ -7,17 +7,15 @@
 
 (defn transform
   "Allows the user to visualize the site data after Nuzzle's modifications."
-  [config & {:as config-overrides}]
-  {:pre [(or (nil? config-overrides) (map? config-overrides))]}
+  [config]
   (log/info "🔍🐈 Returning transformed config")
-  (conf/load-config config :config-overrides config-overrides))
+  (conf/load-config config))
 
 (defn transform-diff
   "Pretty prints the diff between the config in nuzzle.edn and the config after
   Nuzzle's transformations."
-  [config & {:as config-overrides}]
-  {:pre [(or (nil? config-overrides) (map? config-overrides))]}
-  (let [transformed-config (conf/load-config config :config-overrides config-overrides)]
+  [config]
+  (let [transformed-config (conf/load-config config)]
     (log/info "🔍🐈 Printing Nuzzle's config transformations diff")
     (ddiff/pretty-print (ddiff/diff config transformed-config))))
 
@@ -25,13 +23,11 @@
   "Publishes the website to :nuzzle/publish-dir. The overlay directory is
   overlayed on top of the publish directory after the web pages have been
   published."
-  [config & {:as config-overrides}]
-  {:pre [(or (nil? config-overrides) (map? config-overrides))]}
-  (-> (conf/load-config config :config-overrides config-overrides)
+  [config]
+  (-> (conf/load-config config)
       (publish/publish-site)))
 
 (defn serve
   "Starts a server using http-kit for development."
-  [config & {:as config-overrides}]
-  {:pre [(or (nil? config-overrides) (map? config-overrides))]}
-  (server/start-server config :config-overrides config-overrides))
+  [config]
+  (server/start-server config))

--- a/src/nuzzle/api.clj
+++ b/src/nuzzle/api.clj
@@ -7,32 +7,31 @@
 
 (defn transform
   "Allows the user to visualize the site data after Nuzzle's modifications."
-  [& {:as config-overrides}]
+  [config & {:as config-overrides}]
   {:pre [(or (nil? config-overrides) (map? config-overrides))]}
   (log/info "🔍🐈 Returning transformed config")
-  (conf/load-default-config :config-overrides config-overrides))
+  (conf/load-config config :config-overrides config-overrides))
 
 (defn transform-diff
   "Pretty prints the diff between the config in nuzzle.edn and the config after
   Nuzzle's transformations."
-  [& {:as config-overrides}]
+  [config & {:as config-overrides}]
   {:pre [(or (nil? config-overrides) (map? config-overrides))]}
-  (let [raw-config (conf/read-config-from-path "nuzzle.edn")
-        transformed-config (conf/load-default-config :config-overrides config-overrides)]
+  (let [transformed-config (conf/load-config config :config-overrides config-overrides)]
     (log/info "🔍🐈 Printing Nuzzle's config transformations diff")
-    (ddiff/pretty-print (ddiff/diff raw-config transformed-config))))
+    (ddiff/pretty-print (ddiff/diff config transformed-config))))
 
 (defn publish
   "Publishes the website to :nuzzle/publish-dir. The overlay directory is
   overlayed on top of the publish directory after the web pages have been
   published."
-  [& {:as config-overrides}]
+  [config & {:as config-overrides}]
   {:pre [(or (nil? config-overrides) (map? config-overrides))]}
-  (-> (conf/load-default-config :config-overrides config-overrides)
+  (-> (conf/load-config config :config-overrides config-overrides)
       (publish/publish-site)))
 
 (defn serve
   "Starts a server using http-kit for development."
-  [& {:as config-overrides}]
+  [config & {:as config-overrides}]
   {:pre [(or (nil? config-overrides) (map? config-overrides))]}
-  (server/start-server :config-overrides config-overrides))
+  (server/start-server config :config-overrides config-overrides))

--- a/src/nuzzle/config.clj
+++ b/src/nuzzle/config.clj
@@ -110,7 +110,6 @@
   "Creates fully transformed config with or without drafts."
   [{:nuzzle/keys [build-drafts?] :as config} & {:as opts}]
   {:pre [(map? config)] :post [#(map? %)]}
-  ;; Allow users to define their own overrides via deep-merge
   (letfn [(apply-defaults [config]
             (let [config-defaults {:nuzzle/publish-dir "out"
                                    :nuzzle/server-port 6899}]
@@ -171,11 +170,10 @@
       (add-get-config-to-pages $))))
 
 (defn load-config
-  "Read a config EDN file and validate it."
-  [config & {:keys [config-overrides] :as opts}]
+  "Load a config var or map and validate it."
+  [config & {:as opts}]
   ;; (print-stack-trace (ex-info "LOADING CONFIG" {:path config-path}) 12)
   (-> (if (var? config) (var-get config) config)
-      (util/deep-merge config-overrides)
       validate-config
       (transform-config opts)))
 

--- a/src/nuzzle/schemas.clj
+++ b/src/nuzzle/schemas.clj
@@ -9,8 +9,6 @@
 
 (def http-url? #(re-find #"^https?://" %))
 
-(def resolvable-symbol? #(try (requiring-resolve %) (catch Throwable _ nil)))
-
 ;; Page map keys
 (s/def :nuzzle/title string?)
 (s/def :nuzzle/feed? boolean?)
@@ -46,7 +44,7 @@
   (s/def :nuzzle.atom-feed/author (s/and keyword? (-> config :nuzzle/author-registry keys set))))
 
 ;; Config keys
-(s/def :nuzzle/render-page (s/and symbol? resolvable-symbol?))
+(s/def :nuzzle/render-page fn?)
 (s/def :nuzzle/base-url http-url?)
 (s/def :nuzzle/syntax-highlighter
   (spell/keys :req-un [:nuzzle.syntax-highlighter/provider]

--- a/src/nuzzle/server.clj
+++ b/src/nuzzle/server.clj
@@ -34,20 +34,19 @@
 
 (defn wrap-load-config
   "Loads config and adds it to the request map under they key :config"
-  [app config-overrides]
+  [app config]
   (fn [request]
-    (let [config (conf/load-default-config :config-overrides config-overrides :lazy-render? true)]
-      (-> request
-          (assoc :config config)
-          (app)))))
+    (-> request
+        (assoc :config (conf/load-config config))
+        app)))
 
-(defn start-server [& {:keys [config-overrides]}]
-  (let [{:nuzzle/keys [server-port]}
-        (conf/load-default-config :config-overrides config-overrides :lazy-render? true)]
+(defn start-server [config & {:keys [config-overrides]}]
+  (let [{:nuzzle/keys [server-port] :as config}
+        (conf/load-config config :config-overrides config-overrides :lazy-render? true)]
     (log/log-start-server server-port)
     (-> handle-page-request
         (wrap-overlay-dir)
-        (wrap-load-config config-overrides)
+        (wrap-load-config config)
         (wrap-content-type)
         (wrap-stacktrace)
         (http/run-server {:port server-port}))))

--- a/src/nuzzle/server.clj
+++ b/src/nuzzle/server.clj
@@ -40,9 +40,9 @@
         (assoc :config (conf/load-config config))
         app)))
 
-(defn start-server [config & {:keys [config-overrides]}]
+(defn start-server [config]
   (let [{:nuzzle/keys [server-port] :as config}
-        (conf/load-config config :config-overrides config-overrides :lazy-render? true)]
+        (conf/load-config config :lazy-render? true)]
     (log/log-start-server server-port)
     (-> handle-page-request
         (wrap-overlay-dir)

--- a/test/nuzzle/config_test.clj
+++ b/test/nuzzle/config_test.clj
@@ -1,67 +1,18 @@
 (ns nuzzle.config-test
   (:require
    [clojure.test :refer [deftest testing is]]
-   [nuzzle.config :as conf]))
-
-(def config-path "test-resources/edn/config-1.edn")
-
-(defn config [] (conf/read-config-from-path config-path))
-
-(def config-2-path "test-resources/edn/config-2-bad.edn")
-
-(def render-page (constantly [:h1 "test"]))
-
-(deftest read-config-from-path
-  (is (= (conf/read-config-from-path config-path)
-         {:nuzzle/publish-dir "/tmp/nuzzle-test-out",
-          :nuzzle/base-url "https://foobar.com"
-          :nuzzle/sitemap? true
-          :nuzzle/build-drafts? true,
-          :nuzzle/render-page 'nuzzle.config-test/render-page,
-          :nuzzle/author-registry {:donna {:email "donnah@mail.com",
-                                           :name "Donna Hayward",
-                                           :url "https://donnahayward.com"},
-                                   :josie {:name "Josie Packard"},
-                                   :shelly {:email "shellyj@mail.com", :name "Shelly Johnson"}}
-          :nuzzle/atom-feed {:author :donna,
-                             :subtitle "Rants about foo and thoughts about bar",
-                             :title "Foo's blog"}
-          :nuzzle/overlay-dir "public",
-          :meta {:twitter "https://twitter/foobar"},
-          [] {:nuzzle/title "Home"},
-          [:about] {:nuzzle/updated "2022-05-09T12:00Z",
-                    :nuzzle/content "test-resources/markdown/about.md",
-                    :nuzzle/title "About"},
-          [:blog :favorite-color] {:nuzzle/content "test-resources/markdown/favorite-color.md",
-                                   :nuzzle/updated "2022-05-09T12:00Z"
-                                   :nuzzle/feed? true,
-                                   :nuzzle/author :josie
-                                   :nuzzle/tags #{:colors},
-                                   :nuzzle/title "What's My Favorite Color? It May Suprise You."},
-          [:blog :nuzzle-rocks] {:nuzzle/content "test-resources/markdown/nuzzle-rocks.md",
-                                 :nuzzle/updated "2022-05-09T12:00Z",
-                                 :nuzzle/author :shelly
-                                 :nuzzle/feed? true,
-                                 :nuzzle/tags #{:nuzzle},
-                                 :nuzzle/title "10 Reasons Why Nuzzle Rocks"},
-          [:blog :why-nuzzle] {:nuzzle/content "test-resources/markdown/why-nuzzle.md",
-                               :nuzzle/updated "2022-05-09T12:00Z"
-                               :nuzzle/feed? true,
-                               :nuzzle/author :donna
-                               :nuzzle/tags #{:nuzzle},
-                               :nuzzle/title "Why I Made Nuzzle"}})))
+   [nuzzle.config :as conf]
+   [nuzzle.test-util :as test-util]))
 
 (deftest validate-config
   (testing "bad config fails with expound output"
-    (let [error-str (with-out-str (try (-> config-2-path
-                                           conf/read-config-from-path
-                                           conf/validate-config)
+    (let [error-str (with-out-str (try (-> test-util/config-2 conf/load-config)
                                     (catch Throwable _ nil)))]
       (is (re-find #"Spec failed" error-str))
       (is (re-find #"should contain key:.{6}:nuzzle/base-url" error-str))))
   (testing "author registry author validation works"
     (let [config {:nuzzle/base-url "https://twin.peaks"
-                  :nuzzle/render-page 'nuzzle.config-test/render-page
+                  :nuzzle/render-page nuzzle.test-util/render-page
                   :nuzzle/author-registry {:laura {:name "Laura Palmer"}}
                   [:blog :douglas-firs] {:nuzzle/title "Douglas Firs Smell Really Freakin Good"
                                          :nuzzle/author :agent-cooper}}
@@ -83,7 +34,7 @@
           [:tags :colors]
           {:nuzzle/index #{[:blog :favorite-color]},
            :nuzzle/title "#colors"}}
-         (conf/create-tag-index-page-entries (config)))))
+         (conf/create-tag-index-page-entries test-util/config-1))))
 
 (deftest create-hierarchical-index-page-entries
   (is (= {[:blog-posts]
@@ -106,11 +57,10 @@
           []
           {:nuzzle/index #{[:about] [:blog]}
            :nuzzle/title "Home"}}
-         (conf/create-hierarchical-index-page-entries (config)))))
+         (conf/create-hierarchical-index-page-entries test-util/config-1))))
 
 (deftest create-get-config
-  (let [config (conf/load-config-from-path config-path)
-        get-config (conf/create-get-config config)]
+  (let [get-config (-> test-util/config-1 conf/load-config conf/create-get-config)]
     (is (= "https://foobar.com" (get-config :nuzzle/base-url)))
     (is (= "https://twitter/foobar" (get-config :meta :twitter)))
     (is (= [:about] (get-config [:about] :nuzzle/url)))

--- a/test/nuzzle/content_test.clj
+++ b/test/nuzzle/content_test.clj
@@ -1,12 +1,8 @@
 (ns nuzzle.content-test
   (:require
    [clojure.test :refer [deftest testing is run-tests]]
-   [nuzzle.config :as conf]
-   [nuzzle.content :as con]))
-
-(def config-path "test-resources/edn/config-1.edn")
-
-(defn config [] (conf/load-config-from-path config-path))
+   [nuzzle.content :as con]
+   [nuzzle.test-util :as test-util]))
 
 (deftest generate-highlight-command
   (testing "generating chroma command"
@@ -52,7 +48,7 @@
 ;;              (con/highlight-code code "clojure" {:nuzzle/syntax-highlighter {:provider :pygments :line-numbers? true}}))))))
 
 (deftest create-render-content-fn
-  (let [render-content (con/create-render-content-fn [:about] (config))]
+  (let [render-content (con/create-render-content-fn [:about] test-util/config-1)]
     (is (fn? render-content))
     (is (= (list [:h1 {:id "about"} "About"] [:p {} "This is a site for testing the Clojure static site generator called Nuzzle."])
            (render-content)))))

--- a/test/nuzzle/test_util.clj
+++ b/test/nuzzle/test_util.clj
@@ -1,0 +1,76 @@
+(ns nuzzle.test-util)
+
+(def render-page (constantly [:h1 "test"]))
+
+(def config-1
+  {:nuzzle/publish-dir "/tmp/nuzzle-test-out",
+   :nuzzle/base-url "https://foobar.com"
+   :nuzzle/sitemap? true
+   :nuzzle/build-drafts? true,
+   :nuzzle/render-page render-page,
+   :nuzzle/author-registry {:donna {:email "donnah@mail.com",
+                                    :name "Donna Hayward",
+                                    :url "https://donnahayward.com"},
+                            :josie {:name "Josie Packard"},
+                            :shelly {:email "shellyj@mail.com", :name "Shelly Johnson"}}
+   :nuzzle/atom-feed {:author :donna,
+                      :subtitle "Rants about foo and thoughts about bar",
+                      :title "Foo's blog"}
+   :nuzzle/overlay-dir "public",
+   :meta {:twitter "https://twitter/foobar"},
+   [] {:nuzzle/title "Home"},
+   [:about] {:nuzzle/updated "2022-05-09T12:00Z",
+             :nuzzle/content "test-resources/markdown/about.md",
+             :nuzzle/title "About"},
+   [:blog :favorite-color] {:nuzzle/content "test-resources/markdown/favorite-color.md",
+                            :nuzzle/updated "2022-05-09T12:00Z"
+                            :nuzzle/feed? true,
+                            :nuzzle/author :josie
+                            :nuzzle/tags #{:colors},
+                            :nuzzle/title "What's My Favorite Color? It May Suprise You."},
+   [:blog :nuzzle-rocks] {:nuzzle/content "test-resources/markdown/nuzzle-rocks.md",
+                          :nuzzle/updated "2022-05-09T12:00Z",
+                          :nuzzle/author :shelly
+                          :nuzzle/feed? true,
+                          :nuzzle/tags #{:nuzzle},
+                          :nuzzle/title "10 Reasons Why Nuzzle Rocks"},
+   [:blog :why-nuzzle] {:nuzzle/content "test-resources/markdown/why-nuzzle.md",
+                        :nuzzle/updated "2022-05-09T12:00Z"
+                        :nuzzle/feed? true,
+                        :nuzzle/author :donna
+                        :nuzzle/tags #{:nuzzle},
+                        :nuzzle/title "Why I Made Nuzzle"}})
+
+
+(def config-2
+  {:nuzzle/build-drafts? true
+   :nuzzle/render-page render-page
+   :nuzzle/sitemap? true
+   :nuzzle/overlay-dir "public"
+   :nuzzle/publish-dir "/tmp/nuzzle-test-out"
+
+   [] {:nuzzle/title "Home"}
+
+   [:blog :nuzzle-rocks]
+   {:nuzzle/title "10 Reasons Why Nuzzle Rocks"
+    :nuzzle/content "test-resources/markdown/nuzzle-rocks.md"
+    :nuzzle/updated "2022-05-09"
+    :nuzzle/tags #{:nuzzle}}
+
+   [:blog :why-nuzzle]
+   {:nuzzle/title "Why I Made Nuzzle"
+    :nuzzle/content "test-resources/markdown/why-nuzzle.md"
+    :nuzzle/tags #{:nuzzle}}
+
+   [:blog :favorite-color]
+   {:nuzzle/title "What's My Favorite Color? It May Suprise You."
+    :nuzzle/content "test-resources/markdown/favorite-color.md"
+    :nuzzle/tags #{:colors}}
+
+   [:about]
+   {:nuzzle/title "About"
+    :nuzzle/content "test-resources/markdown/about.md"}
+
+   :meta
+   {:twitter "https://twitter/foobar"}})
+


### PR DESCRIPTION
    Stop using nuzzle.edn to hold config value and start requiring that the
    config is passed directly into the functions in `nuzzle.api`. This
    allows the user to directly embed functions in the config map and allows
    the user to pre-process the config map with functions provided by
    Nuzzle in the future.
    
    This is a big step in my vision towards a Nuzzle interface that puts
    more control into the hands of users and doesn't do a lot of magic
    behind the scenes.

Fixes #133