### PR TITLE
Move :nuzzle/server-port to nuzzle.api.server kw args (#144)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Nuzzle's whole interface is just four functions in the `nuzzle.api` namespace:
   - `:overlay-dir` - Optional keyword argument, a path to a directory that will be overlayed on top of the static web site, useful for including static assets. Defaults to `nil` (no overlay).
 - `(serve <config>)`: Starts a web server (http-kit) for a live preview of the website, building each page from scratch upon each request.
   - `:overlay-dir` - Same as above.
+  - `:port`: Port for server to listen on. Defaults to `6899`.
 - `(transform <config>)`: Returns your config after Nuzzle's transformations.
 - `(transform-diff <config>)`: Pretty prints a colorized diff of your config before and after Nuzzle's transformations.
 
@@ -116,7 +117,6 @@ The Nuzzle config must be a map where each key is either a keyword or a vector o
 - `:nuzzle/publish-dir` - A path to a directory to publish the site into. Defaults to `"out"`.
 - `:nuzzle/ignored-pages` - A collection of page entry keys that should be removed as part of the config transformation step. Can be used to ignore pages that Nuzzle creates automatically.
 - `:nuzzle/author-registry` - A map of keyword keys to map values which contain information about a website author. Used in conjunction with the `:nuzzle/author` page entry key.
-- `:nuzzle/server-port` - A port number for the development server to listen on. Defaults to `6899`.
 
 The following config options provide functionality above and beyond basic static site generation. They are totally optional.
 

--- a/src/nuzzle/config.clj
+++ b/src/nuzzle/config.clj
@@ -111,8 +111,7 @@
   [{:nuzzle/keys [build-drafts?] :as config} & {:as opts}]
   {:pre [(map? config)] :post [#(map? %)]}
   (letfn [(apply-defaults [config]
-            (let [config-defaults {:nuzzle/publish-dir "out"
-                                   :nuzzle/server-port 6899}]
+            (let [config-defaults {:nuzzle/publish-dir "out"}]
               (merge config-defaults config)))
           (handle-drafts [config]
             (if build-drafts?

--- a/src/nuzzle/log.clj
+++ b/src/nuzzle/log.clj
@@ -43,8 +43,8 @@
 (defn log-publish-end []
   (info "✅🐈 Publishing successful"))
 
-(defn log-start-server [server-port]
-  (info "✨🐈 Starting development server on port" server-port))
+(defn log-start-server [port]
+  (info "✨🐈 Starting development server on port" port))
 
 (defn log-rendering-page [page]
   (info "⚡🐈 Rendering page:")

--- a/src/nuzzle/schemas.clj
+++ b/src/nuzzle/schemas.clj
@@ -53,7 +53,6 @@
   (spell/keys :req-un [:nuzzle.atom-feed/title]
               :opt-un [:nuzzle.atom-feed/subtitle :nuzzle.atom-feed/author :nuzzle.atom-feed/logo :nuzzle.atom-feed/icon]))
 (s/def :nuzzle/sitemap? boolean?)
-(s/def :nuzzle/server-port (s/int-in 1024 65536))
 (s/def :nuzzle/publish-dir string?)
 (s/def :nuzzle/build-drafts? boolean?)
 (s/def :nuzzle/custom-elements (s/map-of keyword? symbol?))
@@ -75,6 +74,9 @@
                      :nuzzle/sitemap? :nuzzle/custom-elements :nuzzle/publish-dir
                      :nuzzle/author-registry :nuzzle/ignore-pages])
    (s/every :nuzzle/config-entry)))
+
+;; Might use this later for function instrumentation
+;; (s/def :nuzzle/server-port (s/int-in 1024 65536))
 
 (comment
  (s/explain

--- a/test/nuzzle/integration_test.clj
+++ b/test/nuzzle/integration_test.clj
@@ -72,7 +72,6 @@
                 config))
     (is (= normalized-config
            {:nuzzle/publish-dir "out",
-            :nuzzle/server-port 6899,
             :nuzzle/base-url "https://ashketchum.com",
             :nuzzle/render-page render-page
             []


### PR DESCRIPTION
Move another value from config map into keyword args of API functions.

Fixes #144