### PR TITLE
Move :nuzzle/publish-dir value from config to kw args (#148)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,10 @@ clj -Sdeps '{:deps {codes.stel/nuzzle {:mvn/version "0.5.320"}}}'
 ```
 
 Nuzzle's whole interface is just four functions in the `nuzzle.api` namespace:
-- `(nuzzle.api.publish config {:keys [base-url overlay-dir]})`: Exports the static site to disk.
+- `(nuzzle.api.publish config {:keys [base-url overlay-dir publish-dir]})`: Exports the static site to disk.
   - `base-url` - Optional but required for sitemap and Atom feed generation. URL where site will be hosted. Must start with "http://" or "https://".
   - `overlay-dir` - Optional path to a directory that will be overlayed on top of the static web site, useful for including static assets. Defaults to `nil` (no overlay).
+  - `publish-dir` - Optional path to a directory to publish the site into. Be careful, all prior contents of this directory will be lost! Defaults to `"dist"`.
 - `(nuzzle.api.serve config {:keys [overlay-dir port]})`: Starts a web server (http-kit) for a live preview of the website, building each page from scratch upon each request.
   - `overlay-dir` - Same as above.
   - `port`: Optional port number for server to listen on. Defaults to `6899`.
@@ -113,7 +114,6 @@ The Nuzzle config must be a map where each key is either a keyword or a vector o
 
 - `:nuzzle/render-page` - A fully qualified symbol that must resolve to your page rendering function. Required.
 - `:nuzzle/build-drafts?` - A boolean that indicates whether pages marked as a draft should be included. Defaults to `false` (no drafts included).
-- `:nuzzle/publish-dir` - A path to a directory to publish the site into. Defaults to `"out"`.
 - `:nuzzle/ignored-pages` - A collection of page entry keys that should be removed as part of the config transformation step. Can be used to ignore pages that Nuzzle creates automatically.
 - `:nuzzle/author-registry` - A map of keyword keys to map values which contain information about a website author. Used in conjunction with the `:nuzzle/author` page entry key.
 

--- a/src/nuzzle/config.clj
+++ b/src/nuzzle/config.clj
@@ -110,10 +110,7 @@
   "Creates fully transformed config with or without drafts."
   [{:nuzzle/keys [build-drafts?] :as config} & {:as opts}]
   {:pre [(map? config)] :post [#(map? %)]}
-  (letfn [(apply-defaults [config]
-            (let [config-defaults {:nuzzle/publish-dir "out"}]
-              (merge config-defaults config)))
-          (handle-drafts [config]
+  (letfn [(handle-drafts [config]
             (if build-drafts?
               (do (log/log-build-drafts) config)
               (do (log/log-remove-drafts)
@@ -158,7 +155,6 @@
                                    (vector? ckey) (assoc :nuzzle/get-config get-config))))
                {} config)))]
     (as-> config $
-      (apply-defaults $)
       (handle-drafts $)
       (convert-time-strs $)
       (util/deep-merge $ (create-tag-index-page-entries $))

--- a/src/nuzzle/schemas.clj
+++ b/src/nuzzle/schemas.clj
@@ -53,7 +53,7 @@
   (spell/keys :req-un [:nuzzle.atom-feed/title]
               :opt-un [:nuzzle.atom-feed/subtitle :nuzzle.atom-feed/author :nuzzle.atom-feed/logo :nuzzle.atom-feed/icon]))
 (s/def :nuzzle/sitemap? boolean?)
-(s/def :nuzzle/publish-dir string?)
+;; (s/def :nuzzle/publish-dir string?)
 (s/def :nuzzle/build-drafts? boolean?)
 (s/def :nuzzle/custom-elements (s/map-of keyword? symbol?))
 (s/def :nuzzle/author-registry (s/map-of keyword? :nuzzle.author-registry/entry))
@@ -71,7 +71,7 @@
   (s/and
    (spell/keys :req [:nuzzle/render-page]
                :opt [:nuzzle/syntax-highlighter :nuzzle/atom-feed :nuzzle/build-drafts?
-                     :nuzzle/sitemap? :nuzzle/custom-elements :nuzzle/publish-dir
+                     :nuzzle/sitemap? :nuzzle/custom-elements
                      :nuzzle/author-registry :nuzzle/ignore-pages])
    (s/every :nuzzle/config-entry)))
 

--- a/test/nuzzle/integration_test.clj
+++ b/test/nuzzle/integration_test.clj
@@ -71,8 +71,7 @@
     (is (every? (fn [[ckey cval]] (or (not (vector? ckey)) (contains? cval :nuzzle/get-config)))
                 config))
     (is (= normalized-config
-           {:nuzzle/publish-dir "out",
-            :nuzzle/render-page render-page
+           {:nuzzle/render-page render-page
             []
             {:nuzzle/title "Home"
              :nuzzle/content "test-resources/markdown/homepage-introduction.md",

--- a/test/nuzzle/publish_test.clj
+++ b/test/nuzzle/publish_test.clj
@@ -63,37 +63,12 @@
     (is (= (-> "test-resources/sites/config-1-site/feed.xml" slurp str/trim)
            (publish/create-atom-feed config rendered-site-index :base-url "https://foobar.com" :deterministic? true)))))
 
-(deftest publish-feed
-  (let [temp-dir (fs/create-temp-dir)
-        feed-path (fs/path temp-dir "feed.xml")
-        reference-feed-path (fs/path "test-resources/sites/config-1-site/feed.xml")
-        config (-> test-util/config-1 (assoc :nuzzle/publish-dir (str temp-dir)) conf/load-config)
-        rendered-site-index (conf/create-site-index config)]
-    (publish/publish-atom-feed config rendered-site-index :deterministic? true :base-url "https://foobar.com")
-    (is (fs/exists? feed-path))
-    (is (fs/exists? reference-feed-path))
-    (is (= (-> feed-path str slurp str/trim)
-           (-> reference-feed-path str slurp str/trim)))))
-
-(deftest publish-sitemap
-  (let [temp-dir (fs/create-temp-dir)
-        sitemap-path (fs/path temp-dir "sitemap.xml")
-        reference-sitemap-path (fs/path "test-resources/xml/config-1-sitemap.xml")
-        config (-> test-util/config-1 (assoc :nuzzle/publish-dir (str temp-dir)) conf/load-config)
-        rendered-site-index (conf/create-site-index config)]
-    (publish/publish-sitemap config rendered-site-index :base-url "https://foobar.com")
-    (is (fs/exists? sitemap-path))
-    (is (fs/exists? reference-sitemap-path))
-    (is (= (-> sitemap-path str slurp str/trim)
-           (-> reference-sitemap-path str slurp str/trim)))))
-
 (deftest publish-site
   (let [temp-site-dir (str (fs/create-temp-dir))
         reference-site-dir (str (fs/path "test-resources/sites/config-1-site"))
-        config (-> test-util/config-1
-                   (assoc :nuzzle/publish-dir (str temp-site-dir))
-                   conf/load-config)
-        _ (publish/publish-site config :overlay-dir "test-resources/public" :deterministic? true :base-url "https://foobar.com")
+        config (-> test-util/config-1 conf/load-config)
+        _ (publish/publish-site config :overlay-dir "test-resources/public" :deterministic? true
+                                :base-url "https://foobar.com" :publish-dir (str temp-site-dir))
         mismatches (diff-dirs temp-site-dir reference-site-dir)]
     (doseq [mismatch mismatches
             :let [rel->abs-path (fn [parent-dir path] (str parent-dir "/" path))

--- a/test/nuzzle/test_util.clj
+++ b/test/nuzzle/test_util.clj
@@ -3,8 +3,7 @@
 (def render-page (constantly [:h1 "test"]))
 
 (def config-1
-  {:nuzzle/publish-dir "/tmp/nuzzle-test-out",
-   :nuzzle/sitemap? true
+  {:nuzzle/sitemap? true
    :nuzzle/build-drafts? true,
    :nuzzle/render-page render-page,
    :nuzzle/author-registry {:donna {:email "donnah@mail.com",
@@ -44,7 +43,6 @@
   {:nuzzle/build-drafts? true
    :nuzzle/render-page render-page
    :nuzzle/sitemap? true
-   :nuzzle/publish-dir "/tmp/nuzzle-test-out"
 
    [] {:nuzzle/title "Home"}
 


### PR DESCRIPTION
Previously the `publish-dir` value was specified in the config map, now it is passed directly to the `nuzzle.api.publish` function via keyword argument.

Part of the effort to move top-level config values into function arguments.

Fixes #148 