### PR TITLE
Remove author-registry, require author maps in page values (#150)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,6 @@ The Nuzzle config must be a map where each key is either a keyword or a vector o
 - `:nuzzle/render-page` - A fully qualified symbol that must resolve to your page rendering function. Required.
 - `:nuzzle/build-drafts?` - A boolean that indicates whether pages marked as a draft should be included. Defaults to `false` (no drafts included).
 - `:nuzzle/ignored-pages` - A collection of page entry keys that should be removed as part of the config transformation step. Can be used to ignore pages that Nuzzle creates automatically.
-- `:nuzzle/author-registry` - A map of keyword keys to map values which contain information about a website author. Used in conjunction with the `:nuzzle/author` page entry key.
 
 The following config options provide functionality above and beyond basic static site generation. They are totally optional.
 
@@ -132,7 +131,7 @@ The following config options provide functionality above and beyond basic static
 - `:nuzzle/tags`: A set of keywords where each keyword represents a tag name.
 - `:nuzzle/updated`: A timestamp string representing when the page was last updated.
 - `:nuzzle/summary`: A string summary of the page content.
-- `:nuzzle/author`: A keyword representing the author of the page. The author must be registered in the `:nuzzle/author-registry` map.
+- `:nuzzle/author`: A map representing the author of the page. Must have a `:name`, optionally `:email` and `:url`.
 
 ## Understanding the Nuzzle Config
 

--- a/src/nuzzle/config.clj
+++ b/src/nuzzle/config.clj
@@ -6,15 +6,11 @@
    [nuzzle.content :as content]
    [nuzzle.hiccup :as hiccup]
    [nuzzle.log :as log]
-   [nuzzle.schemas :as schemas]
    [nuzzle.util :as util]
    ;; Register spell-spec expound helpers after requiring expound.alpha
    [spell-spec.expound]))
 
 (defn validate-config [config]
-  ;; Redefine valid authors
-  (schemas/redefine-page-author-spec config)
-  (schemas/redefine-feed-author-spec config)
   (if (s/valid? :nuzzle/user-config config)
     config
     (do (expound/expound :nuzzle/user-config config {:theme :figwheel-theme})

--- a/src/nuzzle/publish.clj
+++ b/src/nuzzle/publish.clj
@@ -38,18 +38,17 @@
     {:encoding "UTF-8"}))
 
 (defn create-author-element
-  [{:nuzzle/keys [author-registry] :as _config} author-kw]
-  (let [{:keys [name email url]} (get author-registry author-kw)]
-    (when-not name (throw (ex-info (str "Invalid author keyword: " author-kw) {})))
-    {:tag ::atom/author
-     :content [{:tag ::atom/name
-                :content name}
-               (when email
-                 {:tag ::atom/email
-                  :content email})
-               (when url
-                 {:tag ::atom/uri
-                  :content url})]}))
+  [{:keys [name email url] :as author}]
+  (when-not name (throw (ex-info (str "Invalid author keyword: " (pr-str author)) {:author author})))
+  {:tag ::atom/author
+   :content [{:tag ::atom/name
+              :content name}
+             (when email
+               {:tag ::atom/email
+                :content email})
+             (when url
+               {:tag ::atom/uri
+                :content url})]})
 
 (defn create-atom-feed
   "The optional test-ops map can make build deterministic by setting
@@ -68,7 +67,7 @@
              {:tag ::atom/updated
               :content (str (util/now-trunc-sec))})
            (when-let [feed-author (:author atom-feed)]
-             (create-author-element config feed-author))
+             (create-author-element feed-author))
            (when-let [icon (:icon atom-feed)]
              {:tag ::atom/icon
               :content icon})
@@ -99,7 +98,7 @@
                        (when summary
                          {:tag ::atom/summary
                           :content summary})
-                       (when author (create-author-element config author))]}))}
+                       (when author (create-author-element author))]}))}
    {:encoding "UTF-8"}))
 
 (defn publish-site

--- a/src/nuzzle/schemas.clj
+++ b/src/nuzzle/schemas.clj
@@ -15,33 +15,25 @@
 (s/def :nuzzle/updated (s/or :date date-str? :datetime datetime-str? :zoned-datetime zoned-datetime-str?))
 (s/def :nuzzle/tags (s/coll-of keyword? :kind set?))
 (s/def :nuzzle/draft? boolean?)
-(s/def :nuzzle/author keyword?)
-;; Dynamically redefine :nuzzle/author based on config
-(defn redefine-page-author-spec [config]
-  (s/def :nuzzle/author (s/and keyword? (-> config :nuzzle/author-registry keys set))))
+
+(s/def :nuzzle.author/name string?)
+(s/def :nuzzle.author/email string?)
+(s/def :nuzzle.author/url http-url?)
+(s/def :nuzzle/author
+  (spell/keys :req-un [:nuzzle.author/name]
+              :opt-un [:nuzzle.author/email :nuzzle.author/url]))
 
 ;; Syntax highlighter keys
 (s/def :nuzzle.syntax-highlighter/provider #{:chroma :pygments})
 (s/def :nuzzle.syntax-highlighter/style string?)
 (s/def :nuzzle.syntax-highlighter/line-numbers? boolean?)
 
-;; Author registry keys
-(s/def :nuzzle.author-registry/name string?)
-(s/def :nuzzle.author-registry/email string?)
-(s/def :nuzzle.author-registry/url http-url?)
-(s/def :nuzzle.author-registry/entry
-  (spell/keys :req-un [:nuzzle.author-registry/name]
-              :opt-un [:nuzzle.author-registry/email :nuzzle.author-registry/url]))
 
 ;; Atom feed keys
 (s/def :nuzzle.atom-feed/title string?)
 (s/def :nuzzle.atom-feed/subtitle string?)
 (s/def :nuzzle.atom-feed/logo string?)
 (s/def :nuzzle.atom-feed/icon string?)
-(s/def :nuzzle.atom-feed/author keyword?)
-;; Dynamically redefine :nuzzle/author based on config
-(defn redefine-feed-author-spec [config]
-  (s/def :nuzzle.atom-feed/author (s/and keyword? (-> config :nuzzle/author-registry keys set))))
 
 ;; Config keys
 (s/def :nuzzle/render-page fn?)
@@ -51,12 +43,11 @@
               :opt-un [:nuzzle.syntax-highlighter/style :nuzzle.syntax-highlighter/line-numbers?]))
 (s/def :nuzzle/atom-feed
   (spell/keys :req-un [:nuzzle.atom-feed/title]
-              :opt-un [:nuzzle.atom-feed/subtitle :nuzzle.atom-feed/author :nuzzle.atom-feed/logo :nuzzle.atom-feed/icon]))
+              :opt-un [:nuzzle.atom-feed/subtitle :nuzzle/author :nuzzle.atom-feed/logo :nuzzle.atom-feed/icon]))
 (s/def :nuzzle/sitemap? boolean?)
 ;; (s/def :nuzzle/publish-dir string?)
 (s/def :nuzzle/build-drafts? boolean?)
 (s/def :nuzzle/custom-elements (s/map-of keyword? symbol?))
-(s/def :nuzzle/author-registry (s/map-of keyword? :nuzzle.author-registry/entry))
 (s/def :nuzzle/ignore-pages (s/coll-of :nuzzle/page-key :kind set?))
 
 ;; Config Rules
@@ -71,8 +62,7 @@
   (s/and
    (spell/keys :req [:nuzzle/render-page]
                :opt [:nuzzle/syntax-highlighter :nuzzle/atom-feed :nuzzle/build-drafts?
-                     :nuzzle/sitemap? :nuzzle/custom-elements
-                     :nuzzle/author-registry :nuzzle/ignore-pages])
+                     :nuzzle/sitemap? :nuzzle/custom-elements :nuzzle/ignore-pages])
    (s/every :nuzzle/config-entry)))
 
 ;; Might use this later for function instrumentation

--- a/test/nuzzle/config_test.clj
+++ b/test/nuzzle/config_test.clj
@@ -1,23 +1,23 @@
 (ns nuzzle.config-test
   (:require
-   [clojure.test :refer [deftest testing is]]
+   [clojure.test :refer [deftest is]]
    [nuzzle.config :as conf]
    [nuzzle.test-util :as test-util]))
 
-(deftest validate-config
+;; (deftest validate-config
   ;; (testing "bad config fails with expound output"
   ;;   (let [error-str (with-out-str (try (-> test-util/config-2 conf/load-config)
   ;;                                   (catch Throwable _ nil)))]
   ;;     (is (re-find #"Spec failed" error-str))
   ;;     (is (re-find #"should contain key:.{6}:nuzzle/base-url" error-str))))
-  (testing "author registry author validation works"
-    (let [config {:nuzzle/render-page nuzzle.test-util/render-page
-                  :nuzzle/author-registry {:laura {:name "Laura Palmer"}}
-                  [:blog :douglas-firs] {:nuzzle/title "Douglas Firs Smell Really Freakin Good"
-                                         :nuzzle/author :agent-cooper}}
-          error-str (with-out-str (try (conf/validate-config config) (catch Throwable _ nil)))]
-      (is (re-find #"Spec failed" error-str))
-      (is (re-find #"->\W*config\W*:nuzzle\/author-registry\W*keys\W*set" error-str)))))
+  ;; (testing "author registry author validation works"
+  ;;   (let [config {:nuzzle/render-page nuzzle.test-util/render-page
+  ;;                 :nuzzle/author-registry {:laura {:name "Laura Palmer"}}
+  ;;                 [:blog :douglas-firs] {:nuzzle/title "Douglas Firs Smell Really Freakin Good"
+  ;;                                        :nuzzle/author :agent-cooper}}
+  ;;         error-str (with-out-str (try (conf/validate-config config) (catch Throwable _ nil)))]
+  ;;     (is (re-find #"Spec failed" error-str))
+  ;;     (is (re-find #"->\W*config\W*:nuzzle\/author-registry\W*keys\W*set" error-str)))))
 
 (deftest create-tag-index-page-entries
   (is (= {[:tags :bar]

--- a/test/nuzzle/schemas_test.clj
+++ b/test/nuzzle/schemas_test.clj
@@ -4,11 +4,11 @@
    [clojure.test :refer [deftest is]]
    [nuzzle.schemas]))
 
-(deftest author-registry
-  (is (s/valid? :nuzzle/author-registry {:stel {:name "Stelly Luna"}}))
-  (is (s/valid? :nuzzle/author-registry {:stel {:name "Stelly Luna" :email "stel@email.com"}}))
-  (is (s/valid? :nuzzle/author-registry {:stel {:name "Stelly Luna" :email "stel@email.com" :url "https://stel.com"}}))
-  (is (not (s/valid? :nuzzle/author-registry {:stel {:name 77777777777}})))
-  (is (not (s/valid? :nuzzle/author-registry {:stel {:name "Stelly Luna" :email "stel@email.com" :url "stel.com"}})))
-  (is (not (s/valid? :nuzzle/author-registry {:stel {:name "Stelly Luna" :emailz "stel@email.com"}}))))
-  (is (not (s/valid? :nuzzle/author-registry {:stel {:email "stel@email.com"}})))
+(deftest author
+  (is (s/valid? :nuzzle/author {:name "Stelly Luna"}))
+  (is (s/valid? :nuzzle/author {:name "Stelly Luna" :email "stel@email.com"}))
+  (is (s/valid? :nuzzle/author {:name "Stelly Luna" :email "stel@email.com" :url "https://stel.com"}))
+  (is (not (s/valid? :nuzzle/author {:name 77777777777})))
+  (is (not (s/valid? :nuzzle/author {:name "Stelly Luna" :email "stel@email.com" :url "stel.com"})))
+  (is (not (s/valid? :nuzzle/author {:name "Stelly Luna" :emailz "stel@email.com"}))))
+  (is (not (s/valid? :nuzzle/author {:email "stel@email.com"})))

--- a/test/nuzzle/test_util.clj
+++ b/test/nuzzle/test_util.clj
@@ -2,16 +2,17 @@
 
 (def render-page (constantly [:h1 "test"]))
 
+(def authors {:donna {:email "donnah@mail.com",
+                      :name "Donna Hayward",
+                      :url "https://donnahayward.com"},
+              :josie {:name "Josie Packard"},
+              :shelly {:email "shellyj@mail.com", :name "Shelly Johnson"}})
+
 (def config-1
   {:nuzzle/sitemap? true
    :nuzzle/build-drafts? true,
    :nuzzle/render-page render-page,
-   :nuzzle/author-registry {:donna {:email "donnah@mail.com",
-                                    :name "Donna Hayward",
-                                    :url "https://donnahayward.com"},
-                            :josie {:name "Josie Packard"},
-                            :shelly {:email "shellyj@mail.com", :name "Shelly Johnson"}}
-   :nuzzle/atom-feed {:author :donna,
+   :nuzzle/atom-feed {:author (authors :donna) ,
                       :subtitle "Rants about foo and thoughts about bar",
                       :title "Foo's blog"}
    :meta {:twitter "https://twitter/foobar"},
@@ -22,22 +23,21 @@
    [:blog :favorite-color] {:nuzzle/content "test-resources/markdown/favorite-color.md",
                             :nuzzle/updated "2022-05-09T12:00Z"
                             :nuzzle/feed? true,
-                            :nuzzle/author :josie
+                            :nuzzle/author (authors :josie)
                             :nuzzle/tags #{:colors},
                             :nuzzle/title "What's My Favorite Color? It May Suprise You."},
    [:blog :nuzzle-rocks] {:nuzzle/content "test-resources/markdown/nuzzle-rocks.md",
                           :nuzzle/updated "2022-05-09T12:00Z",
-                          :nuzzle/author :shelly
+                          :nuzzle/author (authors :shelly)
                           :nuzzle/feed? true,
                           :nuzzle/tags #{:nuzzle},
                           :nuzzle/title "10 Reasons Why Nuzzle Rocks"},
    [:blog :why-nuzzle] {:nuzzle/content "test-resources/markdown/why-nuzzle.md",
                         :nuzzle/updated "2022-05-09T12:00Z"
                         :nuzzle/feed? true,
-                        :nuzzle/author :donna
+                        :nuzzle/author (authors :donna)
                         :nuzzle/tags #{:nuzzle},
                         :nuzzle/title "Why I Made Nuzzle"}})
-
 
 (def config-2
   {:nuzzle/build-drafts? true


### PR DESCRIPTION
Previously the `:nuzzle/author-registry` config key contained a map of keywords to author maps. Now that config option is gone and the author maps must be included directly in the page maps.

This is part of an effort to remove the top-level config values.

Fixes #150 