### PR TITLE
Remove ignore-pages config value completely (#152)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,6 @@ The Nuzzle config must be a map where each key is either a keyword or a vector o
 
 - `:nuzzle/render-page` - A fully qualified symbol that must resolve to your page rendering function. Required.
 - `:nuzzle/build-drafts?` - A boolean that indicates whether pages marked as a draft should be included. Defaults to `false` (no drafts included).
-- `:nuzzle/ignored-pages` - A collection of page entry keys that should be removed as part of the config transformation step. Can be used to ignore pages that Nuzzle creates automatically.
 
 The following config options provide functionality above and beyond basic static site generation. They are totally optional.
 
@@ -257,8 +256,6 @@ Nuzzle adds both hierarchical and tag index pages automatically for all hierarch
  {:nuzzle/title "Tags"
   :nuzzle/index #{[:tags :comfort-food] [:tags :japanese]}}}
 ```
-
-> You may not want to publish all the index pages that Nuzzle adds to your config. That's ok! You can avoid publishing any page by adding it to the `:nuzzle/ignored-pages` collection.
 
 These added index page entries have an `:nuzzle/index` key with a value that is a set of page entry keys.
 

--- a/src/nuzzle/config.clj
+++ b/src/nuzzle/config.clj
@@ -125,15 +125,6 @@
                         (cond-> cval
                           updated (update :nuzzle/updated util/time-str->?inst)))))
              {} config))
-          (remove-ignored-pages [{:nuzzle/keys [ignore-pages] :as config}]
-            (reduce-kv
-             (fn [acc ckey {:nuzzle/keys [index] :as cval}]
-               (if (contains? ignore-pages ckey)
-                 acc
-                 (if index
-                   (assoc acc ckey (update cval :nuzzle/index #(apply disj % ignore-pages)))
-                   (assoc acc ckey cval))))
-             {} config))
           (add-page-keys [config]
             (reduce-kv
              (fn [acc ckey {:nuzzle/keys [content] :as cval}]
@@ -155,7 +146,6 @@
       (convert-time-strs $)
       (util/deep-merge $ (create-tag-index-page-entries $))
       (util/deep-merge $ (create-hierarchical-index-page-entries $))
-      (remove-ignored-pages $)
       (add-page-keys $)
       ;; Adding get-config must come after all other transformations
       (add-get-config-to-pages $))))

--- a/src/nuzzle/schemas.clj
+++ b/src/nuzzle/schemas.clj
@@ -48,7 +48,6 @@
 ;; (s/def :nuzzle/publish-dir string?)
 (s/def :nuzzle/build-drafts? boolean?)
 (s/def :nuzzle/custom-elements (s/map-of keyword? symbol?))
-(s/def :nuzzle/ignore-pages (s/coll-of :nuzzle/page-key :kind set?))
 
 ;; Config Rules
 (s/def :nuzzle/page-key (s/coll-of keyword? :kind vector?))
@@ -62,7 +61,7 @@
   (s/and
    (spell/keys :req [:nuzzle/render-page]
                :opt [:nuzzle/syntax-highlighter :nuzzle/atom-feed :nuzzle/build-drafts?
-                     :nuzzle/sitemap? :nuzzle/custom-elements :nuzzle/ignore-pages])
+                     :nuzzle/sitemap? :nuzzle/custom-elements])
    (s/every :nuzzle/config-entry)))
 
 ;; Might use this later for function instrumentation


### PR DESCRIPTION
Previously the user could specify pages that were to be stripped from the pages map in the `:nuzzle/ignore-pages` config value. Now that option is removed because users can now dissoc any pages they don't want before passing the config map to the API functions.

Fixes #152 