### PR TITLE
Require users to create a render-content fn per page (#134)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,28 +80,30 @@ Nuzzle builds your static site from a map of configuration values. The config is
 
 If you're from Pallet town, your config might look like this:
 ```clojure
-{:nuzzle/render-page views/render-page
+(ns user
+  (:require [nuzzle.content :refer [md->hiccup]]))
 
- []
- {:nuzzle/title "Home"
-  :nuzzle/content "markdown/homepage-introduction.md"}
+(defn config []
+  {[]
+   {:nuzzle/title "Home"
+    :nuzzle/render-content #(-> "markdown/homepage-introduction.md" slurp md->hiccup)}
 
- [:blog-posts]
- {:nuzzle/title "Blog Posts"
-  :nuzzle/content "markdown/blog-header.md"}
+   [:blog-posts]
+   {:nuzzle/title "Blog Posts"
+    :nuzzle/render-content #(-> "markdown/blog-header.md" slurp md->hiccup)}
 
- [:blog-posts :catching-pikachu]
- {:nuzzle/title "How I Caught Pikachu"
-  :nuzzle/content "markdown/how-i-caught-pikachu.md"}
+   [:blog-posts :catching-pikachu]
+   {:nuzzle/title "How I Caught Pikachu"
+    :nuzzle/render-content #(-> "markdown/how-i-caught-pikachu.md" slurp md->hiccup)}
 
- [:blog-posts :defeating-misty]
- {:nuzzle/title "How I Defeated Misty with Pikachu"
-  :nuzzle/content "markdown/how-i-defeated-misty.md"
-  :nuzzle/draft? true}
+   [:blog-posts :defeating-misty]
+   {:nuzzle/title "How I Defeated Misty with Pikachu"
+    :nuzzle/render-content #(-> "markdown/how-i-defeated-misty.md" slurp md->hiccup)
+    :nuzzle/draft? true}
 
- [:about]
- {:nuzzle/title "About Ash"
-  :nuzzle/content "markdown/about-ash.md"}}
+   [:about]
+   {:nuzzle/title "About Ash"
+    :nuzzle/render-content #(-> "markdown/about-ash.md" slurp md->hiccup)}})
 ```
 
 ## Option and Page Entries

--- a/bb.edn
+++ b/bb.edn
@@ -1,6 +1,6 @@
 {:min-bb-version "0.8.0",
  :tasks {lint (clojure "-M:clj-kondo --lint src test")
          push {:depends [test lint] :task (do (shell "git push origin") (shell "git push origin --tags"))}
-         repl (shell "rlwrap bb clojure -M:repl")
+         repl (shell "rlwrap bb clojure -M:test:repl")
          tag {:depends [test lint] :task (clojure "-T:build tag")}
          test (apply clojure "-M:test -m kaocha.runner" *command-line-args*)}}

--- a/src/nuzzle/content.clj
+++ b/src/nuzzle/content.clj
@@ -1,139 +1,90 @@
 (ns nuzzle.content
-  ;; (:use clojure.stacktrace)
   (:require
    [babashka.fs :as fs]
    [clojure.string :as str]
    [clojure.walk :as w]
    [cybermonday.core :as cm]
-   [cybermonday.utils :as cu]
-   [nuzzle.hiccup :as hiccup]
    [nuzzle.log :as log]
    [nuzzle.util :as util]))
 
-(defn quickfigure-element
-  [[_tag {:keys [src title] :as _attr}]]
-  [:figure [:img {:src src}]
-   [:figcaption [:h4 title]]])
+(defn quickfigure
+  [[_tag {:keys [src alt] :as _attr}]]
+  [:figure [:img {:src src :alt alt}]
+   [:figcaption [:h4 alt]]])
 
-(defn gist-element
+(defn gist
   [[_tag {:keys [user id] :as _attr}]]
   [:script {:type "application/javascript"
             :src (str "https://gist.github.com/" user "/" id ".js")}])
 
-(defn youtube-element
+(defn youtube
   [[_tag {:keys [title id] :as _attr}]]
   [:div {:style "position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;"}
    [:iframe {:src (str "https://www.youtube.com/embed/" id)
              :style "position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;"
              :title title :allowfullscreen true}]])
 
-(defn render-custom-element
-  [[tag & _ :as hiccup]]
-  (case tag
-    :quickfigure (quickfigure-element hiccup)
-    :gist (gist-element hiccup)
-    :youtube (youtube-element hiccup)
-    hiccup))
-
-(defn walk-hiccup-for-custom-elements
-  [hiccup]
-  {:pre [(sequential? hiccup)]}
-  (if (list? hiccup)
-    (map walk-hiccup-for-custom-elements hiccup)
-    (w/prewalk
-     (fn [item]
-       (if (cu/hiccup? item)
-         (if (-> item second map?)
-           (render-custom-element item)
-           (render-custom-element (apply vector (first item) {} (rest item))))
-         item))
-     hiccup)))
+(defn transform-hiccup
+  [hiccup transformations]
+  (w/postwalk
+   (fn [item]
+     (if-let [transformation-fn (and (vector? item) (get transformations (first item)))]
+       (if (-> item second map?)
+         (transformation-fn item)
+         (transformation-fn (apply vector (first item) {} (rest item))))
+       item))
+   hiccup))
 
 (defn generate-chroma-command
-  [file-path language config]
-  (let [{:keys [style line-numbers?]} (:nuzzle/syntax-highlighter config)]
-    ["chroma" (str "--lexer=" language) "--formatter=html" "--html-only"
-     "--html-prevent-surrounding-pre" (when style "--html-inline-styles")
-     (when style (str "--style=" style)) (when line-numbers? "--html-lines")  file-path]))
+  [file-path language & {:keys [style line-numbers?]}]
+  (remove nil?
+          ["chroma" (str "--lexer=" language) "--formatter=html" "--html-only"
+           "--html-prevent-surrounding-pre" (when style "--html-inline-styles")
+           (when style (str "--style=" style)) (when line-numbers? "--html-lines")  file-path]))
 
 (defn generate-pygments-command
-  [file-path language config]
-  (let [{:keys [style line-numbers?]} (:nuzzle/syntax-highlighter config)
-        ;; TODO: turn nowrap on for everything if they release my PR
+  [file-path language & {:keys [style line-numbers?]}]
+  (let [;; TODO: turn nowrap on for everything if they release my PR
         ;; https://github.com/pygments/pygments/issues/2127
-        options [(when-not line-numbers? "nowrap") (when style "noclasses")
-                 (when style (str "style=" style))
-                 (when line-numbers? "linenos=inline")]]
-    ["pygmentize" "-f" "html" "-l" language "-O"
-     (->> options (remove nil?) (str/join ",")) file-path]))
+        options (remove nil?
+                        [(when-not line-numbers? "nowrap") (when style "noclasses")
+                         (when style (str "style=" style))
+                         (when line-numbers? "linenos=inline")])]
+    ["pygmentize" "-f" "html" "-l" language "-O" (str/join "," options) file-path]))
 
-(defn generate-highlight-command
-  [file-path language config]
-  (->>
-   (case (get-in config [:nuzzle/syntax-highlighter :provider])
-    :chroma (generate-chroma-command file-path language config)
-    :pygments (generate-pygments-command file-path language config))
-   (remove nil?)))
+(defn highlight-code [hiccup provider & opts]
+  (let [[tag {classes :class :as attrs} code] hiccup
+        language-matcher #(->> % (re-find #"language-(\S+)") second)
+        language (if (coll? classes)
+                   (some language-matcher classes)
+                   (language-matcher classes))]
+    (if-not language
+      hiccup
+      (let [tmp-file (fs/create-temp-file)
+            tmp-file-path (-> tmp-file fs/canonicalize str)
+            _ (spit tmp-file-path code)
+            highlight-command (case provider
+                                :chroma (generate-chroma-command tmp-file opts)
+                                :pygments (generate-pygments-command tmp-file language opts))
+            {:keys [exit out err]} (apply util/safe-sh highlight-command)]
+        (if (not= 0 exit)
+          (do
+            (log/warn "Syntax highlighting command failed:" (str/join " " highlight-command))
+            (log/warn err)
+            hiccup)
+          (do
+            (fs/delete-if-exists tmp-file)
+            [tag attrs out]))))))
 
-(defn highlight-code [code language config]
-  (let [tmp-file (fs/create-temp-file)
-        tmp-file-path (-> tmp-file fs/canonicalize str)
-        _ (spit tmp-file-path code)
-        highlight-command (generate-highlight-command tmp-file-path language config)
-        {:keys [exit out err]} (apply util/safe-sh highlight-command)]
-    (if (not= 0 exit)
-      (do
-        (log/warn "Syntax highlighting command failed:" (str/join " " highlight-command))
-        (log/warn err)
-        code)
-      (do
-        (fs/delete-if-exists tmp-file)
-        out))))
-
-(defn code-block->hiccup [[_tag-name {:keys [language]} code] config]
-  (if (and language (:nuzzle/syntax-highlighter config))
-    [:pre
-     [:code.code-block (hiccup/raw (highlight-code code language config))]]
-    [:pre [:code.code-block code]]))
-
-(defn process-markdown-file [file config]
-  ;; (print-stack-trace (ex-info "PROCESSING MARKDOWN FILE" {:file file}) 12)
-  (let [code-block-with-config #(code-block->hiccup % config)
-        lower-fns {:markdown/fenced-code-block code-block-with-config
-                   :markdown/indented-code-block code-block-with-config}
-        ;; Avoid the top level :div {}
-        [_ _ & hiccup] (-> file
-                           slurp
-                           (cm/parse-body {:lower-fns lower-fns}))]
-    (walk-hiccup-for-custom-elements hiccup)))
-
-(defn process-html-file
-  [content-file _config]
-  (hiccup/raw (slurp content-file)))
-
-(defn create-render-content-fn
-  "Create a function that turns the :nuzzle/content file into the correct form for the
-  hiccup compiler: vector, list, or raw string"
-  [url config & {:keys [lazy-render?] :as _opts}]
-  {:pre [(or (vector? url) (keyword? url))]}
-  (if-let [content (get-in config [url :nuzzle/content])]
-    (let [content-file (fs/file content)
-          content-ext (fs/extension content-file)]
-      (if (fs/exists? content-file)
-        (cond
-         (#{"md" "markdown"} content-ext) (if lazy-render?
-                                            #(process-markdown-file content-file config)
-                                            (constantly (process-markdown-file content-file config)))
-         (#{"html" "htm"} content-ext) (if lazy-render?
-                                         #(process-html-file content-file config)
-                                         (constantly (process-html-file content-file config)))
-         :else (throw (ex-info (str "Content file " (fs/canonicalize content-file)
-                                    " for page " url " has unrecognized extension "
-                                    content-ext ". Must be one of: md, markdown, html, htm")
-                               {:nuzzle/url url :nuzzle/content content})))
-        ;; If markdown-file is defined but it can't be found, throw an Exception
-        (throw (ex-info (str "Content file " (fs/canonicalize content-file)
-                             " for page " url " not found")
-                        {:nuzzle/url url :nuzzle/content content}))))
-    ;; If :nuzzle/content is not defined, just make a function that returns nil
-    (constantly nil)))
+(defn md->hiccup [md-str]
+  (let [lower-code-block
+        (fn lower-code-block [[_tag-name {:keys [language]} code]]
+          [:pre
+           [:code
+            {:class ["code-block" (when language (str "language-" language))]}
+            code]])
+        lower-fns {:markdown/fenced-code-block lower-code-block
+                   :markdown/indented-code-block lower-code-block}
+        ;; Avoid the top level div [:div {} content...]
+        [_ _ & hiccup] (cm/parse-body md-str {:lower-fns lower-fns})]
+    hiccup))

--- a/src/nuzzle/publish.clj
+++ b/src/nuzzle/publish.clj
@@ -26,15 +26,15 @@
      :content
      (for [[url-str _hiccup] rendered-site-index
            :let [url-vec (util/vectorize-url url-str)
-                 {:nuzzle/keys [content updated]} (get config url-vec)
+                 {:nuzzle/keys [updated]} (get config url-vec)
                  abs-url (str base-url url-str)]]
        {:tag ::sm/url
         :content
         [{:tag ::sm/loc
           :content [abs-url]}
-         (when (or updated content)
+         (when updated
            {:tag ::sm/lastmod
-            :content (str (or updated (util/path->last-mod-inst content)))})]})}
+            :content (str updated)})]})}
     {:encoding "UTF-8"}))
 
 (defn create-author-element
@@ -79,8 +79,8 @@
               :content subtitle})]
           (for [[url-str _] rendered-site-index
                 :let [url-vec (util/vectorize-url url-str)
-                      {:nuzzle/keys [updated summary author title content render-content feed?]} (get config url-vec)
-                      content-result (when (fn? render-content) (render-content))
+                      {:nuzzle/keys [updated summary author title render-content feed?]} (get config url-vec)
+                      content (render-content)
                       abs-url (str base-url url-str)]
                 :when feed?]
             {:tag ::atom/entry
@@ -88,13 +88,13 @@
                         :content title}
                        {:tag ::atom/id
                         :content abs-url}
-                       (when content-result
+                       (when content
                          {:tag ::atom/content
                           :attrs {:type "html"}
-                          :content (str (hiccup/html content-result))})
-                       (when (or updated content)
+                          :content (hiccup/html content)})
+                       (when updated
                          {:tag ::atom/updated
-                          :content (str (or updated (util/path->last-mod-inst content)))})
+                          :content (str updated)})
                        (when summary
                          {:tag ::atom/summary
                           :content summary})

--- a/src/nuzzle/schemas.clj
+++ b/src/nuzzle/schemas.clj
@@ -11,10 +11,15 @@
 
 ;; Page map keys
 (s/def :nuzzle/title string?)
+(s/def :nuzzle/render-content fn?)
 (s/def :nuzzle/feed? boolean?)
 (s/def :nuzzle/updated (s/or :date date-str? :datetime datetime-str? :zoned-datetime zoned-datetime-str?))
 (s/def :nuzzle/tags (s/coll-of keyword? :kind set?))
 (s/def :nuzzle/draft? boolean?)
+(s/def :nuzzle/page-map
+  (spell/keys :req [:nuzzle/title]
+              :opt [:nuzzle/tags :nuzzle/render-content :nuzzle/updated :nuzzle/feed?
+                    :nuzzle/draft? :nuzzle/summary :nuzzle/subtitle]))
 
 (s/def :nuzzle.author/name string?)
 (s/def :nuzzle.author/email string?)
@@ -51,8 +56,6 @@
 
 ;; Config Rules
 (s/def :nuzzle/page-key (s/coll-of keyword? :kind vector?))
-(s/def :nuzzle/page-map (spell/keys :req [:nuzzle/title]
-                                    :opt [:nuzzle/tags :nuzzle/updated :nuzzle/feed? :nuzzle/draft? :nuzzle/summary :nuzzle/subtitle]))
 (s/def :nuzzle/config-entry (s/or :page (s/tuple :nuzzle/page-key :nuzzle/page-map)
                                   :option (s/tuple keyword? any?)))
 

--- a/src/nuzzle/util.clj
+++ b/src/nuzzle/util.clj
@@ -82,10 +82,10 @@
 
 (defn find-hiccup-str
   "Find first string matching regular expression in deeply nested Hiccup tree"
-  [regex hiccup]
+  [hiccup regex]
   (reduce
    (fn [_ item]
-     (let [desc-result (and (vector? item) (find-hiccup-str regex item))]
+     (let [desc-result (and (vector? item) (find-hiccup-str item regex))]
        (or (and (string? item) (re-find regex item) (reduced item))
            (and desc-result (reduced desc-result)))))
    hiccup))

--- a/test/nuzzle/test_util.clj
+++ b/test/nuzzle/test_util.clj
@@ -1,4 +1,6 @@
-(ns nuzzle.test-util)
+(ns nuzzle.test-util
+  (:require
+   [nuzzle.content :refer [md->hiccup]]))
 
 (def render-page (constantly [:h1 "test"]))
 
@@ -18,21 +20,21 @@
    :meta {:twitter "https://twitter/foobar"},
    [] {:nuzzle/title "Home"},
    [:about] {:nuzzle/updated "2022-05-09T12:00Z",
-             :nuzzle/content "test-resources/markdown/about.md",
+             :nuzzle/render-content #(-> "test-resources/markdown/about.md" slurp md->hiccup),
              :nuzzle/title "About"},
-   [:blog :favorite-color] {:nuzzle/content "test-resources/markdown/favorite-color.md",
+   [:blog :favorite-color] {:nuzzle/render-content #(-> "test-resources/markdown/favorite-color.md" slurp md->hiccup),
                             :nuzzle/updated "2022-05-09T12:00Z"
                             :nuzzle/feed? true,
                             :nuzzle/author (authors :josie)
                             :nuzzle/tags #{:colors},
                             :nuzzle/title "What's My Favorite Color? It May Suprise You."},
-   [:blog :nuzzle-rocks] {:nuzzle/content "test-resources/markdown/nuzzle-rocks.md",
+   [:blog :nuzzle-rocks] {:nuzzle/render-content #(-> "test-resources/markdown/nuzzle-rocks.md" slurp md->hiccup),
                           :nuzzle/updated "2022-05-09T12:00Z",
                           :nuzzle/author (authors :shelly)
                           :nuzzle/feed? true,
                           :nuzzle/tags #{:nuzzle},
                           :nuzzle/title "10 Reasons Why Nuzzle Rocks"},
-   [:blog :why-nuzzle] {:nuzzle/content "test-resources/markdown/why-nuzzle.md",
+   [:blog :why-nuzzle] {:nuzzle/render-content #(-> "test-resources/markdown/why-nuzzle.md" slurp md->hiccup),
                         :nuzzle/updated "2022-05-09T12:00Z"
                         :nuzzle/feed? true,
                         :nuzzle/author (authors :donna)
@@ -48,18 +50,18 @@
 
    [:blog :nuzzle-rocks]
    {:nuzzle/title "10 Reasons Why Nuzzle Rocks"
-    :nuzzle/content "test-resources/markdown/nuzzle-rocks.md"
+    :nuzzle/render-content #(-> "test-resources/markdown/nuzzle-rocks.md" slurp md->hiccup)
     :nuzzle/updated "2022-05-09"
     :nuzzle/tags #{:nuzzle}}
 
    [:blog :why-nuzzle]
    {:nuzzle/title "Why I Made Nuzzle"
-    :nuzzle/content "test-resources/markdown/why-nuzzle.md"
+    :nuzzle/render-content #(-> "test-resources/markdown/why-nuzzle.md" slurp md->hiccup)
     :nuzzle/tags #{:nuzzle}}
 
    [:blog :favorite-color]
    {:nuzzle/title "What's My Favorite Color? It May Suprise You."
-    :nuzzle/content "test-resources/markdown/favorite-color.md"
+    :nuzzle/render-content #(->"test-resources/markdown/favorite-color.md" slurp md->hiccup)
     :nuzzle/tags #{:colors}}
 
    [:about]

--- a/test/nuzzle/util_test.clj
+++ b/test/nuzzle/util_test.clj
@@ -23,4 +23,4 @@
 
 (deftest find-hiccup-str
   (is (= "foobar"
-         (util/find-hiccup-str #"foo" [:div "bar" [:div {:class "foobaz"} [:p "foobar"]]]))))
+         (util/find-hiccup-str [:div "bar" [:div {:class "foobaz"} [:p "foobar"]]] #"foo"))))


### PR DESCRIPTION
    Previously Nuzzle created a `:nuzzle/render-content` function for each
    page based on the `:nuzzle/content` value. Now `:nuzzle/content` is
    removed and users must specify their own `:nuzzle/render-content`
    function for every page. If they don't include a `render-content`
    function, a function will be added that constantly returns `nil`. This
    allows the user to have complete control and understanding of how each
    page's content gets made.
    
    The `nuzzle.content` namespace has been reformatted and will probably be
    merged with `nuzzle.hiccup` soon. `nuzzle.content/md->hiccup` is an
    important function that can be used to include markdown files for page
    content.

Fixes #134